### PR TITLE
Add PM2.5 measurement value

### DIFF
--- a/custom_components/philips_airplus/const.py
+++ b/custom_components/philips_airplus/const.py
@@ -69,6 +69,7 @@ PROP_FILTER_CLEAN_NOMINAL = "filter_clean_nominal"
 PROP_FILTER_CLEAN_REMAINING = "filter_clean_remaining"
 PROP_FILTER_REPLACE_NOMINAL = "filter_replace_nominal"
 PROP_FILTER_REPLACE_REMAINING = "filter_replace_remaining"
+PROP_PM25 = "pm25"
 PROP_SESSION_OWNER = "owner"
 
 

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -38,6 +38,7 @@ from .const import (
     PROP_FILTER_REPLACE_NOMINAL,
     PROP_FILTER_REPLACE_REMAINING,
     PROP_MODE,
+    PROP_PM25,
     PROP_POWER_FLAG,
     SCAN_INTERVAL,
     TOKEN_REFRESH_BUFFER,
@@ -378,6 +379,10 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             mode_value = properties[prop_mode]
             mode_name = self._get_mode_name(mode_value)
             _LOGGER.debug("Mode updated: %s (%s)", mode_name, mode_value)
+
+        prop_pm25 = self._model_config.get("properties", {}).get(PROP_PM25)
+        if prop_pm25 and prop_pm25 in properties:
+            _LOGGER.debug("PM2.5 updated: %s µg/m³", properties[prop_pm25])
 
         # Trigger coordinator update so entities refresh state in HA
         self.async_set_updated_data(

--- a/custom_components/philips_airplus/models.yaml
+++ b/custom_components/philips_airplus/models.yaml
@@ -36,3 +36,4 @@ models:
       filter_replace_reset_raw: "D0540E"
       device_model: "ctn"
       device_brand: "D01S04"
+      pm25: "D03221"

--- a/custom_components/philips_airplus/sensor.py
+++ b/custom_components/philips_airplus/sensor.py
@@ -8,9 +8,11 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
     UnitOfTime,
 )
@@ -23,6 +25,7 @@ from .const import (
     DOMAIN,
     PROP_FILTER_CLEAN_REMAINING,
     PROP_FILTER_REPLACE_REMAINING,
+    PROP_PM25,
 )
 from .coordinator import PhilipsAirplusDataCoordinator
 
@@ -30,6 +33,15 @@ _LOGGER = logging.getLogger(__name__)
 
 # Sensor descriptions
 SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
+    # Air quality
+    SensorEntityDescription(
+        key="pm25",
+        name="PM2.5",
+        device_class=SensorDeviceClass.PM25,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        icon="mdi:molecule",
+    ),
     # Filter sensors
     SensorEntityDescription(
         key="filter_replace_percentage",
@@ -116,6 +128,17 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
         """Return the native value of the sensor."""
         key = self.entity_description.key
         
+        if key == "pm25":
+            if not self.coordinator.data:
+                return None
+            device_state = self.coordinator.data.get("device_state", {})
+            raw_key = self.coordinator._model_config.get("properties", {}).get(
+                PROP_PM25
+            )
+            if raw_key:
+                return device_state.get(raw_key)
+            return None
+
         if key.startswith("filter_"):
             # Filter data from filter_info
             if self.coordinator.data:


### PR DESCRIPTION
This adds a Home Assistant sensor value for the PM2.5 concentration measured by the air purifier. I tested this with my AC0650.

Closes #9.