### PR TITLE
feat: add AC0651/10 support (air quality sensors, standby monitor switch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Philips Air+ Home Assistant Integration
 
-This custom integration allows you to control your Philips Air+ AC0650/10 air purifier through Home Assistant. It communicates with the Philips/Versuni cloud service using the same protocol as the official mobile app.
+This custom integration allows you to control your Philips Air+ air purifier through Home Assistant. It communicates with the Philips/Versuni cloud service using the same protocol as the official mobile app.
 
 ## Features
 
@@ -9,6 +9,8 @@ This custom integration allows you to control your Philips Air+ AC0650/10 air pu
 - **Filter Monitoring**: Monitor filter life for both replace and clean filters
 - **Maintenance Resets**: Reset clean/replace filter timers via buttons or services
 - **Real-time Updates**: Receive real-time status updates via MQTT
+- **Air Quality Sensors**: PM2.5 concentration and allergen index (AC0651/10)
+- **Standby Monitor**: Toggle sensor standby mode (AC0651/10)
 
 ## Services
 
@@ -20,8 +22,12 @@ This integration registers two Home Assistant services under the `philips_airplu
 
 ## Supported Devices
 
-- Philips Air+ AC0650/10 (tested)
-- Other Air+ models very unlikely to work!! (Most likely could be easily ported)
+| Model | Fan | Filter Monitoring | Air Quality | Standby Monitor |
+|-------|-----|-------------------|-------------|-----------------|
+| AC0650/10 | ✅ | ✅ | — | — |
+| AC0651/10 | ✅ | ✅ | ✅ PM2.5, Allergen Index | ✅ |
+
+Other Air+ models sharing the same MQTT protocol may work but are untested.
 
 ## Installation
 
@@ -70,7 +76,7 @@ This integration is based on reverse-engineering the Philips Air+ mobile app pro
 
 ## Limitations
 
-- Only tested with AC0650/10 model
+- Tested with AC0650/10 and AC0651/10 models
 - Requires internet connectivity (cloud-dependent)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Notes:
 
 ## Development
 
-This integration is based on reverse-engineering the Philips Air+ mobile app protocol.
+This integration is based on reverse-engineering the Philips Air+ mobile app protocol. This repository is a fork of https://github.com/ShorMeneses/philips-airplus-homeassistant, it has been modified to additionally support AC0651/10 air purifiers. The code has been created by Antrophic's Claude Code, as I do not like "whitespace aware languages" and I am not willing to adapt to them... 
 
 ## Limitations
 

--- a/custom_components/philips_airplus/__init__.py
+++ b/custom_components/philips_airplus/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.FAN,
     Platform.SENSOR,
     Platform.BUTTON,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/philips_airplus/__init__.py
+++ b/custom_components/philips_airplus/__init__.py
@@ -11,8 +11,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady
-
 from .const import DOMAIN, CONF_ENABLE_MQTT
 from . import config_flow  # needed so HA can build the options flow
 from .coordinator import PhilipsAirplusDataCoordinator
@@ -145,13 +143,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Entity registry check failed: %s; proceeding with setup.", exc)
 
     coordinator = PhilipsAirplusDataCoordinator(hass, entry)
-    
-    try:
-        await coordinator.async_setup()
-        await coordinator.async_config_entry_first_refresh()
-    except Exception as ex:
-        raise ConfigEntryNotReady(f"Unable to connect to Philips Air+ device: {ex}") from ex
-    
+
+    # async_config_entry_first_refresh calls _async_setup() internally (via
+    # DataUpdateCoordinator.__wrap_async_setup), then performs the first data
+    # refresh.  It raises ConfigEntryNotReady on connection failure and
+    # ConfigEntryAuthFailed on permanent auth failure — both handled by HA.
+    await coordinator.async_config_entry_first_refresh()
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     # Register domain services once (not per entry)

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -17,6 +17,7 @@ from .api import PhilipsAirplusAPIClient, PhilipsAirplusDevice, build_client_id
 from .auth import PhilipsAirplusAuth, AuthenticationExpired
 from .const import (
     AUTH_MODE_OAUTH,
+    DOMAIN,
     CONF_ACCESS_TOKEN,
     CONF_AUTH_MODE,
     CONF_CLIENT_ID,
@@ -59,6 +60,7 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=entry.title,
             update_interval=SCAN_INTERVAL,
         )
@@ -174,8 +176,16 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             # Load models asynchronously (fixes blocking I/O warning)
             await self._model_manager.async_load_models()
 
-            # Load default model config (will be updated when we get model from device)
-            self._model_config = self._model_manager.get_model_config("AC0650/10")
+            # Load model config — use a previously identified model if available (survives
+            # coordinator reloads), otherwise fall back to the default AC0650/10.
+            _domain_data = self.hass.data.get(DOMAIN, {})
+            _key = f"identified_model_{self._device_uuid}"
+            cached_model = _domain_data.get(_key)
+            self._model_config = self._model_manager.get_model_config(
+                cached_model or "AC0650/10"
+            )
+            if cached_model:
+                _LOGGER.debug("Restored cached model config: %s", cached_model)
 
             # Ensure access token is valid (or refreshed) before any auth-dependent API calls.
             if self._auth.expires_at:
@@ -397,6 +407,11 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             _LOGGER.debug("Device model reported: %s", model)
             # Update model config if it changed
             self._model_config = self._model_manager.get_model_config(model)
+            # Cache the identified model in hass.data so future coordinator instances
+            # (e.g. after a config entry reload) can use it immediately.
+            self.hass.data.setdefault(DOMAIN, {})[
+                f"identified_model_{self._device_uuid}"
+            ] = model
             # Re-publish current state so sensors re-evaluate with the new model config
             self.async_set_updated_data(
                 {
@@ -614,6 +629,3 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         if self._api_client:
             await self._api_client.close()
 
-    async def async_setup(self) -> None:
-        """Set up the coordinator."""
-        await self._async_setup()

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -397,6 +397,16 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             _LOGGER.debug("Device model reported: %s", model)
             # Update model config if it changed
             self._model_config = self._model_manager.get_model_config(model)
+            # Re-publish current state so sensors re-evaluate with the new model config
+            self.async_set_updated_data(
+                {
+                    "device_state": self._device_state,
+                    "filter_data": self._filter_data,
+                    "filter_info": self._get_filter_info() or {},
+                    "connected": self._connected,
+                    "last_update": self._last_update,
+                }
+            )
 
     def _process_filter_update(self, properties: Dict[str, Any]) -> None:
         """Process filter update."""

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -539,6 +539,18 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             "last_update": self._last_update,
         }
 
+    async def set_property(self, prop_key: str, value: Any) -> bool:
+        """Set a device property by model-config key (e.g. 'standby_monitor')."""
+        if not self._mqtt_client or not self._mqtt_client.is_connected():
+            return False
+
+        raw_key = self._model_config.get("properties", {}).get(prop_key)
+        if not raw_key:
+            _LOGGER.error("No raw key found for property '%s'", prop_key)
+            return False
+
+        return self._mqtt_client.set_property(raw_key, value)
+
     async def set_fan_speed(self, speed: int) -> bool:
         """Set fan speed."""
         if not self._mqtt_client or not self._mqtt_client.is_connected():

--- a/custom_components/philips_airplus/models.yaml
+++ b/custom_components/philips_airplus/models.yaml
@@ -36,3 +36,36 @@ models:
       filter_replace_reset_raw: "D0540E"
       device_model: "ctn"
       device_brand: "D01S04"
+
+  "AC0651/10":
+    name: "Philips Air+ AC0651/10"
+    modes:
+      Auto: 1
+      Sleep: 17
+      Turbo: 18
+    speeds: [17, 1, 18]
+    protocol:
+      transport: mqtt
+      topic_template: "da_ctrl/{device_id}/to_ncp"
+      ports:
+        control: "Control"
+        status: "Status"
+        filter_read: "filtRd"
+        filter_write: "filtWr"
+    properties:
+      fan_speed: "D0310C"
+      mode: "D0310C"
+      power: "D0310D"
+      filter_replace_nominal: "D05408"
+      filter_replace_remaining: "D0540E"
+      filter_clean_nominal: "D05207"
+      filter_clean_remaining: "D0520D"
+      filter_clean_reset_raw: "D0520D"
+      filter_replace_reset_raw: "D0540E"
+      device_model: "ctn"
+      device_brand: "D01S04"
+      # Air quality sensors (identified from MQTT Status port on AC0651/10)
+      pm25: "D03221"           # PM2.5 concentration (µg/m³)
+      allergen_index: "D03120" # Allergen index
+      standby_monitor: "D03134" # Sensor standby monitor (diagnostic)
+      diag_D0312C: "D0312C"   # Unknown diagnostic property (always 4 on AC0651/10)

--- a/custom_components/philips_airplus/models.yaml
+++ b/custom_components/philips_airplus/models.yaml
@@ -65,7 +65,13 @@ models:
       device_model: "ctn"
       device_brand: "D01S04"
       # Air quality sensors (identified from MQTT Status port on AC0651/10)
-      pm25: "D03221"           # PM2.5 concentration (µg/m³)
-      allergen_index: "D03120" # Allergen index
+      pm25: "D03221"            # PM2.5 concentration (µg/m³)
+      allergen_index: "D03120"  # Allergen index
       standby_monitor: "D03134" # Sensor standby monitor (diagnostic)
-      diag_D0312C: "D0312C"   # Unknown diagnostic property (always 4 on AC0651/10)
+      diag_D0312C: "D0312C"    # Unknown diagnostic property (always 4 on AC0651/10)
+    # Sensor keys to expose as HA entities (must match MODEL_SENSOR_DESCRIPTIONS in sensor.py)
+    sensors:
+      - pm25
+      - allergen_index
+      - standby_monitor
+      - diag_D0312C

--- a/custom_components/philips_airplus/models.yaml
+++ b/custom_components/philips_airplus/models.yaml
@@ -73,5 +73,7 @@ models:
     sensors:
       - pm25
       - allergen_index
-      - standby_monitor
       - diag_D0312C
+    # Switch keys to expose as HA entities (must match MODEL_SWITCH_DESCRIPTIONS in switch.py)
+    switches:
+      - standby_monitor

--- a/custom_components/philips_airplus/mqtt_client.py
+++ b/custom_components/philips_airplus/mqtt_client.py
@@ -370,6 +370,28 @@ class PhilipsAirplusMQTTClient:
         
         return success
 
+    def set_property(self, raw_key: str, value: Any) -> bool:
+        """Set a single device property via the Control port."""
+        if not self._connected:
+            _LOGGER.error("MQTT not connected")
+            return False
+
+        payload = self._build_command_payload(
+            'setPort',
+            PORT_CONTROL,
+            {raw_key: value},
+        )
+
+        _LOGGER.debug("Setting property %s to %s", raw_key, value)
+        res = self._publish(payload)
+
+        try:
+            self.request_port_status(PORT_STATUS)
+        except Exception:
+            pass
+
+        return res
+
     def reset_filter_clean(self) -> bool:
         """Reset clean-filter maintenance timer (matches official app MQTT publish)."""
         if not self._connected:

--- a/custom_components/philips_airplus/sensor.py
+++ b/custom_components/philips_airplus/sensor.py
@@ -79,12 +79,6 @@ MODEL_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         name="Allergen Index",
         icon="mdi:flower-pollen",
     ),
-    "standby_monitor": SensorEntityDescription(
-        key="standby_monitor",
-        name="Sensor Standby Monitor",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:eye-check-outline",
-    ),
     "diag_D0312C": SensorEntityDescription(
         key="diag_D0312C",
         name="Diagnostic D0312C",

--- a/custom_components/philips_airplus/sensor.py
+++ b/custom_components/philips_airplus/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -29,17 +29,8 @@ from .coordinator import PhilipsAirplusDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Sensor descriptions
-# Direct raw-ID mapping for device_state sensors (bypasses model-config timing)
-DEVICE_STATE_PROPERTY_MAP: dict[str, str] = {
-    "pm25":           "D03221",
-    "allergen_index": "D03120",
-    "standby_monitor": "D03134",
-    "diag_D0312C":    "D0312C",
-}
-
-SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
-    # Filter sensors
+# Base sensors present on all models (filter diagnostics)
+BASE_SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
     SensorEntityDescription(
         key="filter_replace_percentage",
         name="Filter Replace",
@@ -72,32 +63,35 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
         native_unit_of_measurement=UnitOfTime.HOURS,
         icon="mdi:air-filter",
     ),
-    # Air quality sensors (AC0651/10 and compatible models)
-    SensorEntityDescription(
+]
+
+# Model-specific sensor descriptions, keyed by the sensor key used in models.yaml
+MODEL_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+    "pm25": SensorEntityDescription(
         key="pm25",
         name="PM2.5",
         device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         icon="mdi:air-filter",
     ),
-    SensorEntityDescription(
+    "allergen_index": SensorEntityDescription(
         key="allergen_index",
         name="Allergen Index",
         icon="mdi:flower-pollen",
     ),
-    SensorEntityDescription(
+    "standby_monitor": SensorEntityDescription(
         key="standby_monitor",
         name="Sensor Standby Monitor",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:eye-check-outline",
     ),
-    SensorEntityDescription(
+    "diag_D0312C": SensorEntityDescription(
         key="diag_D0312C",
         name="Diagnostic D0312C",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:help-circle-outline",
     ),
-]
+}
 
 
 async def async_setup_entry(
@@ -106,13 +100,51 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Philips Air+ sensors."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    
-    entities = []
-    for description in SENSOR_DESCRIPTIONS:
-        entities.append(PhilipsAirplusSensor(coordinator, entry, description))
-    
-    async_add_entities(entities)
+    coordinator: PhilipsAirplusDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Always add base (filter) sensors immediately
+    async_add_entities(
+        [PhilipsAirplusSensor(coordinator, entry, d) for d in BASE_SENSOR_DESCRIPTIONS]
+    )
+
+    _model_sensors_added = False
+
+    def _add_model_sensors() -> None:
+        nonlocal _model_sensors_added
+        if _model_sensors_added:
+            return
+        sensor_keys: list[str] = coordinator._model_config.get("sensors", [])
+        if not sensor_keys:
+            return
+        _model_sensors_added = True
+        entities = []
+        for key in sensor_keys:
+            if key in MODEL_SENSOR_DESCRIPTIONS:
+                entities.append(
+                    PhilipsAirplusSensor(coordinator, entry, MODEL_SENSOR_DESCRIPTIONS[key])
+                )
+            else:
+                _LOGGER.warning("Model sensor key '%s' has no description, skipping", key)
+        if entities:
+            _LOGGER.debug(
+                "Adding %d model-specific sensor(s) for %s",
+                len(entities),
+                coordinator._model_config.get("name"),
+            )
+            async_add_entities(entities)
+
+    # Try immediately in case the model was already identified before this platform loaded
+    _add_model_sensors()
+
+    if not _model_sensors_added:
+        # Register a coordinator listener that fires on every data update.
+        # It will add model-specific sensors once the model config is known
+        # and remove itself afterwards.
+        def _on_coordinator_update() -> None:
+            _add_model_sensors()
+
+        unsub = coordinator.async_add_listener(_on_coordinator_update)
+        entry.async_on_unload(unsub)
 
 
 class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
@@ -130,7 +162,7 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.entry = entry
         self.entity_description = description
-        
+
         # Use stable unique_id based on device UUID so entity registry matches
         self._attr_unique_id = f"{entry.data['device_uuid']}_{description.key}"
         self._attr_device_info = {
@@ -149,18 +181,19 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Optional[str | int | float]:
         """Return the native value of the sensor."""
         key = self.entity_description.key
-        
+
         if key.startswith("filter_"):
             if self.coordinator.data:
                 filter_info = self.coordinator.data.get("filter_info", {})
                 return filter_info.get(key.replace("filter_", ""))
 
-        # Direct device_state lookup (raw ID known at sensor level)
-        if key in DEVICE_STATE_PROPERTY_MAP and self.coordinator.data:
+        # Model-specific sensor: look up raw property ID from model config
+        if self.coordinator.data:
             device_state = self.coordinator.data.get("device_state", {})
-            raw_id = DEVICE_STATE_PROPERTY_MAP[key]
-            if raw_id in device_state:
-                return device_state[raw_id]
+            model_props = self.coordinator._model_config.get("properties", {})
+            raw_id = model_props.get(key)
+            if raw_id is not None:
+                return device_state.get(raw_id)
 
         return None
 
@@ -173,9 +206,8 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
         """Return additional state attributes."""
         key = self.entity_description.key
         attributes = {}
-        
+
         if key.startswith("filter_") and self.coordinator.data:
-            # Add filter hours total if available (use calculated filter_info from coordinator data)
             filter_info = self.coordinator.data.get("filter_info", {})
             if key == "filter_replace_percentage":
                 if "replace_hours_total" in filter_info:
@@ -183,5 +215,5 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
             elif key == "filter_clean_percentage":
                 if "clean_hours_total" in filter_info:
                     attributes["total_hours"] = filter_info["clean_hours_total"]
-        
+
         return attributes

--- a/custom_components/philips_airplus/sensor.py
+++ b/custom_components/philips_airplus/sensor.py
@@ -109,6 +109,7 @@ async def async_setup_entry(
             return
         sensor_keys: list[str] = coordinator._model_config.get("sensors", [])
         if not sensor_keys:
+            _model_sensors_added = True
             return
         _model_sensors_added = True
         entities = []

--- a/custom_components/philips_airplus/sensor.py
+++ b/custom_components/philips_airplus/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
     UnitOfTime,
 )
@@ -29,6 +30,14 @@ from .coordinator import PhilipsAirplusDataCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Sensor descriptions
+# Direct raw-ID mapping for device_state sensors (bypasses model-config timing)
+DEVICE_STATE_PROPERTY_MAP: dict[str, str] = {
+    "pm25":           "D03221",
+    "allergen_index": "D03120",
+    "standby_monitor": "D03134",
+    "diag_D0312C":    "D0312C",
+}
+
 SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
     # Filter sensors
     SensorEntityDescription(
@@ -62,6 +71,31 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         icon="mdi:air-filter",
+    ),
+    # Air quality sensors (AC0651/10 and compatible models)
+    SensorEntityDescription(
+        key="pm25",
+        name="PM2.5",
+        device_class=SensorDeviceClass.PM25,
+        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        icon="mdi:air-filter",
+    ),
+    SensorEntityDescription(
+        key="allergen_index",
+        name="Allergen Index",
+        icon="mdi:flower-pollen",
+    ),
+    SensorEntityDescription(
+        key="standby_monitor",
+        name="Sensor Standby Monitor",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:eye-check-outline",
+    ),
+    SensorEntityDescription(
+        key="diag_D0312C",
+        name="Diagnostic D0312C",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:help-circle-outline",
     ),
 ]
 
@@ -117,11 +151,17 @@ class PhilipsAirplusSensor(CoordinatorEntity, SensorEntity):
         key = self.entity_description.key
         
         if key.startswith("filter_"):
-            # Filter data from filter_info
             if self.coordinator.data:
                 filter_info = self.coordinator.data.get("filter_info", {})
                 return filter_info.get(key.replace("filter_", ""))
-        
+
+        # Direct device_state lookup (raw ID known at sensor level)
+        if key in DEVICE_STATE_PROPERTY_MAP and self.coordinator.data:
+            device_state = self.coordinator.data.get("device_state", {})
+            raw_id = DEVICE_STATE_PROPERTY_MAP[key]
+            if raw_id in device_state:
+                return device_state[raw_id]
+
         return None
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/philips_airplus/services.yaml
+++ b/custom_components/philips_airplus/services.yaml
@@ -1,0 +1,27 @@
+reset_filter_clean:
+  name: Reset Filter Clean Timer
+  description: Resets the clean-filter maintenance timer on the Philips Air+ device.
+  fields:
+    device_uuid:
+      name: Device UUID
+      description: >
+        UUID of the target device (without the "da-" prefix). If omitted, all
+        connected devices are reset.
+      required: false
+      example: "5cb63131-f829-4330-83cf-28b5f27a38c4"
+      selector:
+        text:
+
+reset_filter_replace:
+  name: Reset Filter Replace Timer
+  description: Resets the replace-filter maintenance timer on the Philips Air+ device.
+  fields:
+    device_uuid:
+      name: Device UUID
+      description: >
+        UUID of the target device (without the "da-" prefix). If omitted, all
+        connected devices are reset.
+      required: false
+      example: "5cb63131-f829-4330-83cf-28b5f27a38c4"
+      selector:
+        text:

--- a/custom_components/philips_airplus/switch.py
+++ b/custom_components/philips_airplus/switch.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
             return
         switch_keys: list[str] = coordinator._model_config.get("switches", [])
         if not switch_keys:
+            _switches_added = True
             return
         _switches_added = True
         entities = []

--- a/custom_components/philips_airplus/switch.py
+++ b/custom_components/philips_airplus/switch.py
@@ -1,0 +1,128 @@
+"""Switch entities for Philips Air+ integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PhilipsAirplusDataCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Model-specific switch descriptions, keyed by the switch key used in models.yaml
+MODEL_SWITCH_DESCRIPTIONS: dict[str, SwitchEntityDescription] = {
+    "standby_monitor": SwitchEntityDescription(
+        key="standby_monitor",
+        name="Sensor Standby Monitor",
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:eye-check-outline",
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Philips Air+ switches."""
+    coordinator: PhilipsAirplusDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    _switches_added = False
+
+    def _add_model_switches() -> None:
+        nonlocal _switches_added
+        if _switches_added:
+            return
+        switch_keys: list[str] = coordinator._model_config.get("switches", [])
+        if not switch_keys:
+            return
+        _switches_added = True
+        entities = []
+        for key in switch_keys:
+            if key in MODEL_SWITCH_DESCRIPTIONS:
+                entities.append(
+                    PhilipsAirplusSwitch(coordinator, entry, MODEL_SWITCH_DESCRIPTIONS[key])
+                )
+            else:
+                _LOGGER.warning("Model switch key '%s' has no description, skipping", key)
+        if entities:
+            _LOGGER.debug(
+                "Adding %d model-specific switch(es) for %s",
+                len(entities),
+                coordinator._model_config.get("name"),
+            )
+            async_add_entities(entities)
+
+    _add_model_switches()
+
+    if not _switches_added:
+        def _on_coordinator_update() -> None:
+            _add_model_switches()
+
+        unsub = coordinator.async_add_listener(_on_coordinator_update)
+        entry.async_on_unload(unsub)
+
+
+class PhilipsAirplusSwitch(CoordinatorEntity, SwitchEntity):
+    """Representation of a Philips Air+ switch."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PhilipsAirplusDataCoordinator,
+        entry: ConfigEntry,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.entry = entry
+        self.entity_description = description
+
+        self._attr_unique_id = f"{entry.data['device_uuid']}_{description.key}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.data["device_uuid"])},
+            "name": entry.data["device_name"],
+            "manufacturer": "Philips",
+            "model": self.coordinator._model_config.get("name", "Air+ Device"),
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.is_connected
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the switch is on."""
+        if not self.coordinator.data:
+            return None
+        device_state = self.coordinator.data.get("device_state", {})
+        model_props = self.coordinator._model_config.get("properties", {})
+        raw_id = model_props.get(self.entity_description.key)
+        if raw_id is None:
+            return None
+        value = device_state.get(raw_id)
+        if value is None:
+            return None
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.coordinator.set_property(self.entity_description.key, 1)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.coordinator.set_property(self.entity_description.key, 0)
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()


### PR DESCRIPTION
 ## Summary

  Adds support for the **AC0651/10** model.

  ### New entities for AC0651/10
  - **PM2.5** sensor (µg/m³) — MQTT property `D03221`
  - **Allergen Index** sensor — MQTT property `D03120`
  - **Diagnostic D0312C** sensor — MQTT property `D0312C`
  - **Sensor Standby Monitor** switch (EntityCategory.CONFIG) — MQTT property `D03134`, writes 0/1 via Control port

  ### Bug fixes (affect all models)
  - **`NameError: name 'DOMAIN' is not defined`** — `DOMAIN` was used in `coordinator.py` but never imported; silently
  killed setup on every start
  - **Double `_async_setup()` call** — caused two concurrent MQTT connections with the same `client_id`
  - **`ConfigEntryAuthFailed` swallowed as `ConfigEntryNotReady`** — permanent auth failures were incorrectly treated as
   retryable
  - **HA 2026 deprecation** — pass `config_entry=entry` to `DataUpdateCoordinator.__init__()` (breaks in HA 2026.8
  without it)
  - **Missing `services.yaml`** — caused repeated log errors on startup

  ### Architecture
  - `models.yaml` drives which entities each model gets via `sensors:` and `switches:` lists
  - Model-specific entities are added lazily once the device reports its model via the MQTT Config port; for models
  without extra entities no coordinator listener is registered
  - Identified model is cached in `hass.data` so reloads restore AC0651/10 immediately without waiting for a Config port
   MQTT response

  ## Tested
  - AC0651/10: all entities appear and update correctly
  - AC0651/10: standby monitor switch toggles correctly
  - AC0650/10: existing entities unchanged (no second device available for full smoke-test)
  
Please note: Claude Code created the code!