### PR TITLE
feat: Added AC1715 model support

### DIFF
--- a/custom_components/philips_airplus/fan.py
+++ b/custom_components/philips_airplus/fan.py
@@ -83,9 +83,10 @@ class PhilipsAirplusFan(CoordinatorEntity, FanEntity):
     def is_on(self) -> bool:
         """Return True if the fan is on."""
         power = self._get_device_property(PROP_POWER_FLAG)
+        if power is not None and int(power) > 0:
+            return True
         if power is not None and int(power) == 0:
             return False
-            
         speed = self._get_device_property(PROP_FAN_SPEED)
         if speed is None:
             return False

--- a/custom_components/philips_airplus/fan.py
+++ b/custom_components/philips_airplus/fan.py
@@ -83,6 +83,8 @@ class PhilipsAirplusFan(CoordinatorEntity, FanEntity):
     def is_on(self) -> bool:
         """Return True if the fan is on."""
         power = self._get_device_property(PROP_POWER_FLAG)
+        if power is not None and int(power) > 0:
+            return True
         if power is not None and int(power) == 0:
             return False
             

--- a/custom_components/philips_airplus/models.yaml
+++ b/custom_components/philips_airplus/models.yaml
@@ -36,3 +36,28 @@ models:
       filter_replace_reset_raw: "D0540E"
       device_model: "ctn"
       device_brand: "D01S04"
+  "AC1715/10":
+    name: "Philips Air+ AC1715/10"
+    modes:
+      Auto: 1
+      Sleep: 17
+      Turbo: 18
+    speeds: [17, 1, 18]
+    protocol:
+      transport: mqtt
+      topic_template: "da_ctrl/{device_id}/to_ncp"
+      ports:
+        control: "Control"
+        status: "Status"
+        filter_read: "filtRd"
+        filter_write: "filtWr"
+      properties:
+        fan_speed: "D03120"
+        mode: "D03120"
+        power: "D0310D"
+        filter_replace_nominal: "D05408"
+        filter_replace_remaining: "D0540E"
+        filter_clean_nominal: "D05207"
+        filter_clean_remaining: "D0520D"
+        filter_clean_reset_raw: "D0520D"
+        filter_replace_reset_raw: "D0540E"


### PR DESCRIPTION
## Summary
- Add AC1715/10 model definition to `models.yaml` with correct property keys (`D03120` for fan speed/mode instead of `D0310C`)
- Fix `is_on` in `fan.py` to check the power flag (`D0310D`) before falling through to the speed check — on the AC1715, `D0310C` is always 0 even when the device is running, so the previous logic always reported the fan as off

## Context
The AC1715 uses `D0310D` as a power flag (0=off, 2=on) and `D03120` for fan speed/mode, unlike the AC0650 which uses `D0310C` for both speed and mode. Without these changes, the AC1715 connects and reports diagnostics but the power toggle doesn't work correctly (requires double-click to turn off because HA always thinks the device is off).

Tested with AC1715/10 (Wi-Fi FW 1.7.0, Device FW 0.0.9). Power on/off, Auto/Sleep/Turbo preset modes, and speed slider all working.