### PR TITLE
Fix MQTT reconnection dead-ends that leave the integration offline

### DIFF
--- a/custom_components/philips_airplus/auth.py
+++ b/custom_components/philips_airplus/auth.py
@@ -198,6 +198,23 @@ class PhilipsAirplusAuth:
             _LOGGER.error("Auth initialization failed: %s", ex)
             return False
 
+    async def refresh_signature(self) -> bool:
+        """Fetch a fresh MQTT custom-authorizer signature for the current token.
+
+        The signature sent in the x-amz-customauthorizer-signature header must
+        match the access token presented at connect time, so this should be
+        called before any (re)connect attempt that follows a token refresh.
+        """
+        if not self.access_token:
+            return False
+        try:
+            self.signature = await self._fetch_signature()
+            _LOGGER.debug("Signature refreshed")
+            return True
+        except Exception as ex:
+            _LOGGER.warning("Failed to refresh signature: %s", ex)
+            return False
+
     async def ensure_access_token(self) -> bool:
         """Ensure we have a valid access token, refreshing if necessary."""
         if not self.refresh_token:
@@ -251,15 +268,15 @@ class PhilipsAirplusAuth:
                     "Token refreshed, expires at (from expires_in): %s", self.expires_at
                 )
 
-            # After refreshing token, fetch new signature
-            try:
-                self.signature = await self._fetch_signature()
-                _LOGGER.debug("Signature refreshed after token refresh")
-            except Exception as sig_ex:
+            # After refreshing the token, fetch a matching signature. A stale
+            # signature will cause every subsequent MQTT (re)connect to be
+            # rejected by the custom authorizer, so callers that reconnect
+            # should also call refresh_signature() before connecting.
+            if not await self.refresh_signature():
                 _LOGGER.warning(
-                    "Failed to refresh signature after token refresh: %s", sig_ex
+                    "Signature could not be refreshed after token refresh; "
+                    "it will be retried before the next MQTT reconnect"
                 )
-                # Continue anyway - signature refresh is not critical for token refresh success
 
             _LOGGER.info("Successfully refreshed access token")
 

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -173,7 +173,7 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             # Load models asynchronously (fixes blocking I/O warning)
             await self._model_manager.async_load_models()
 
-            # Load model config — use a previously identified model if available (survives
+            # Load model config: use a previously identified model if available (survives
             # coordinator reloads). Without a cache the config stays empty; entities are
             # registered lazily once the device reports its model via the Config port.
             _domain_data = self.hass.data.get(DOMAIN, {})
@@ -304,22 +304,33 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                                 self._device_name, min(delay * 2, max_delay),
                             )
                             try:
-                                # Refresh token before reconnecting — it may have
+                                # Refresh token before reconnecting: it may have
                                 # expired during the disconnection window.
                                 try:
-                                    token_valid = await self._auth.ensure_access_token()
-                                    if token_valid and self._mqtt_client.access_token != self._auth.access_token:
-                                        _LOGGER.info("Token refreshed before reconnect, updating MQTT credentials")
-                                        self._mqtt_client.access_token = self._auth.access_token
-                                        self._mqtt_client.signature = self._auth.signature
+                                    await self._auth.ensure_access_token()
                                 except AuthenticationExpired:
                                     _LOGGER.error(
-                                        "Token expired and cannot be refreshed for %s — re-authentication required",
+                                        "Token expired and cannot be refreshed for %s, re-authentication required",
                                         self._device_name,
                                     )
-                                    raise ConfigEntryAuthFailed(
-                                        "Authentication expired, please re-authenticate"
-                                    )
+                                    # Raising ConfigEntryAuthFailed from a background
+                                    # task does NOT trigger HA's reauth flow, it just
+                                    # kills this task. Start the reauth flow explicitly.
+                                    self.entry.async_start_reauth(self.hass)
+                                    return
+
+                                # The custom-authorizer signature must match the
+                                # current access token, so refresh it before every
+                                # reconnect attempt. A stale signature (e.g. after a
+                                # failed fetch during token refresh) would otherwise
+                                # make every attempt fail until the next token cycle.
+                                await self._auth.refresh_signature()
+                                self._mqtt_client.access_token = (
+                                    self._auth.access_token or ""
+                                )
+                                self._mqtt_client.signature = (
+                                    self._auth.signature or ""
+                                )
 
                                 if await self._mqtt_client.async_connect():
                                     _LOGGER.info(
@@ -542,17 +553,20 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         return filter_info if filter_info else None
 
     async def _async_update_data(self) -> Dict[str, Any]:
-        """Update device data."""
-        if not self._mqtt_client or not self._mqtt_client.is_connected():
-            raise UpdateFailed("MQTT client not connected")
+        """Update device data, recovering the MQTT connection if needed."""
+        if not self._mqtt_client:
+            raise UpdateFailed("MQTT client not initialized")
 
-        # Ensure token is valid before request
+        # Ensure token is valid before any connectivity decisions. This used
+        # to run only when already connected, which meant a disconnected
+        # integration could never refresh its token or recover.
         try:
             token_valid = await self._auth.ensure_access_token()
             if token_valid:
                 # If token was refreshed, update MQTT credentials
                 if (
                     self._mqtt_client
+                    and self._mqtt_client.is_connected()
                     and self._mqtt_client.access_token != self._auth.access_token
                 ):
                     _LOGGER.info("Token refreshed, updating MQTT credentials")
@@ -571,6 +585,15 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                 "Authentication expired, please re-authenticate"
             ) from ex
 
+        # Self-healing: if we are disconnected and no reconnect task is
+        # already working on it, attempt a reconnect right now. This turns the
+        # regular poll cycle into a recovery mechanism instead of a dead end.
+        if not self._mqtt_client.is_connected():
+            await self._async_attempt_recovery()
+
+        if not self._mqtt_client.is_connected():
+            raise UpdateFailed("MQTT client not connected")
+
         # Request status update
         self._mqtt_client.request_port_status(self._ports["status"])
 
@@ -582,6 +605,35 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             "connected": self._connected,
             "last_update": self._last_update,
         }
+
+    async def _async_attempt_recovery(self) -> None:
+        """Try to re-establish the MQTT connection from the poll cycle.
+
+        Skips if the background reconnect task is already running, so the two
+        recovery paths never fight each other.
+        """
+        if self._reconnect_task and not self._reconnect_task.done():
+            return
+        if not self._mqtt_client:
+            return
+
+        _LOGGER.info(
+            "MQTT disconnected for %s; attempting recovery", self._device_name
+        )
+        # The custom-authorizer signature must match the current access token,
+        # so always fetch a fresh one before reconnecting. A stale signature
+        # would make every reconnect attempt fail with an auth error.
+        await self._auth.refresh_signature()
+        self._mqtt_client.access_token = self._auth.access_token or ""
+        self._mqtt_client.signature = self._auth.signature or ""
+
+        try:
+            if await self._mqtt_client.async_connect():
+                _LOGGER.info("MQTT recovery successful for %s", self._device_name)
+        except Exception as ex:
+            _LOGGER.warning(
+                "MQTT recovery attempt failed for %s: %s", self._device_name, ex
+            )
 
     async def set_property(self, prop_key: str, value: Any) -> bool:
         """Set a device property by model-config key (e.g. 'standby_monitor')."""

--- a/custom_components/philips_airplus/mqtt_client.py
+++ b/custom_components/philips_airplus/mqtt_client.py
@@ -68,7 +68,7 @@ class PhilipsAirplusMQTTClient:
         self.outbound_topic = TOPIC_CONTROL_TEMPLATE.format(device_id=self.device_id)
         self.inbound_topic = TOPIC_STATUS_TEMPLATE.format(device_id=self.device_id)
 
-        # Port names — defaults from const.py, overridable per model via configure_ports()
+        # Port names (defaults from const.py, overridable per model via configure_ports())
         self._port_status = PORT_STATUS
         self._port_control = PORT_CONTROL
         self._port_filter_read = PORT_FILTER_READ
@@ -149,13 +149,18 @@ class PhilipsAirplusMQTTClient:
             self._last_disconnect_time = time.time()
             self._last_disconnect_rc = rc
             try:
-                client.loop_stop()
-            except Exception:
-                pass
-            try:
                 client.disconnect()
             except Exception:
                 pass
+        # Always stop the network loop and drop our reference to this client,
+        # regardless of rc. Previously rc=0 disconnects left the old client
+        # (and its network thread) alive while a new client was created on
+        # reconnect, so zombie callbacks could corrupt the connection state.
+        try:
+            client.loop_stop()
+        except Exception:
+            pass
+        if self._client is client:
             self._client = None
         self._connected = False
         
@@ -191,7 +196,21 @@ class PhilipsAirplusMQTTClient:
                     time.sleep(wait)
             
             headers = self._build_headers()
-            
+
+            # Tear down any leftover client before creating a fresh one, so we
+            # never have two paho network threads alive at once.
+            old_client = self._client
+            if old_client is not None:
+                try:
+                    old_client.loop_stop()
+                except Exception:
+                    pass
+                try:
+                    old_client.disconnect()
+                except Exception:
+                    pass
+                self._client = None
+
             self._client = mqtt.Client(
                 client_id=self.client_id,
                 transport='websockets',
@@ -481,3 +500,13 @@ class PhilipsAirplusMQTTClient:
             return result
         finally:
             self._refreshing_credentials = False
+            # If the reconnect failed we are now disconnected, but the
+            # disconnect callback was suppressed while _refreshing_credentials
+            # was True. Fire it now so the coordinator knows the connection is
+            # down and starts its reconnect loop; otherwise nothing would ever
+            # attempt to reconnect again (integration dead until reload).
+            if not self._connected and self._connection_callback:
+                try:
+                    self._connection_callback(False)
+                except Exception as cb_ex:
+                    _LOGGER.error("Connection callback failed: %s", cb_ex)


### PR DESCRIPTION
Fixes #20

## Problem

Every now and then the integration silently stops working (entities become Unavailable, commands fail) and the only fix is reloading the device/config entry. After reload it works again, as reported in #20. Notably the official Philips Air app keeps working throughout, since it establishes a fresh MQTT connection on each launch, while the integration is stuck unable to reconnect.

## Root causes

I traced this to four related issues in the reconnection logic:

1. **Failed reconnect during token refresh is a dead end.** When the access token is refreshed (roughly every 45 minutes given `TOKEN_REFRESH_BUFFER`), `async_update_credentials()` disconnects and reconnects with the new token while `_refreshing_credentials` suppresses the disconnect callback. If that reconnect fails (transient network blip, connect timeout), no callback ever fires, so the coordinator's reconnect task is never spawned. From then on, `_async_update_data()` raises `UpdateFailed("MQTT client not connected")` on its first line, before any token check or reconnect attempt, every 120 seconds forever. Nothing in the code path can revive the connection.

2. **A failed signature fetch poisons all reconnects.** `refresh_access_token()` treated a signature fetch failure as non-critical, but the `x-amz-customauthorizer-signature` websocket header must match the access token presented at connect time. With a new token and stale signature, every reconnect attempt is rejected by the custom authorizer (typically rc=7, which also triggers the 120 s cooldown) until the next token refresh.

3. **`ConfigEntryAuthFailed` raised in a background task does nothing.** In the reconnect task, raising `ConfigEntryAuthFailed` does not trigger Home Assistant's reauth flow (that only works from `_async_update_data` or setup). It just kills the task as an unhandled error, leaving nothing to ever reconnect.

4. **rc=0 disconnects leak the paho client.** The clean-disconnect branch of `_on_disconnect` did not stop the network loop or clear `self._client`, so a later `_blocking_connect()` created a second client while the zombie's callbacks could still flip `_connected` state.

## Changes

- **coordinator.py**: `_async_update_data()` now validates the token *before* the connectivity check, and when disconnected (with no reconnect task already running) it refreshes the signature and attempts a reconnect via a new `_async_attempt_recovery()` helper. The regular poll cycle becomes a recovery mechanism instead of a dead end. The background reconnect loop refreshes the signature before every attempt and pushes current credentials to the MQTT client; expired refresh tokens now call `entry.async_start_reauth()` instead of raising from a background task.
- **mqtt_client.py**: `async_update_credentials()` fires the connection callback when its reconnect fails, so the coordinator learns the connection is down and starts its retry loop. `_on_disconnect` now stops the loop and clears the client reference for rc=0 disconnects too, and `_blocking_connect()` tears down any leftover client before creating a new one.
- **auth.py**: new `refresh_signature()` method; a signature failure after token refresh is logged and retried before the next reconnect rather than silently ignored.

## Testing

- All three files compile cleanly.
- Unit-level test of the credential-refresh path confirms: failed reconnect now fires the connection callback exactly once with `False` (previously: never fired, integration dead), and a successful refresh fires no spurious disconnect callback.
- Running live against an AC0650/10: previously the integration would go Unavailable roughly daily and stay dead until a manual reload. With this patch the problem has not recurred; disconnects now recover automatically.

## Notes

Behavior on the happy path is unchanged: same topics, same payloads, same `_refreshing_credentials` availability masking during a successful refresh.
