### PR TITLE
feat: email OTP authentication + MQTT stability fixes (v1.0.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,23 @@ Before installing this integration, check whether your device is already support
 
 A Philips Air+ account with your device already set up in the official mobile app.
 
-### Authentication: OAuth PKCE Flow
+### Authentication: Email + Verification Code (Recommended)
 
-1. Add the integration in Home Assistant. A login URL will be shown.
+A simpler, no-browser alternative to the OAuth PKCE flow. No DevTools required.
+
+1. Add the integration in Home Assistant and choose **Email + verification code**
+2. Enter the email address associated with your Philips account
+3. Check your inbox for the verification code
+4. Enter the code in Home Assistant
+5. Select your device
+
+Works with both Philips Air+ and Philips HomeID accounts.
+
+### Authentication: OAuth PKCE Flow (Legacy)
+
+For accounts registered via **Philips Air+** only.
+
+1. Add the integration in Home Assistant. Choose **OAuth PKCE**. A login URL will be shown.
 2. Open that URL in your browser.
 3. Before logging in, open browser DevTools and switch to the Network tab.
 4. Complete the login and authorization on the Philips website.
@@ -59,7 +73,7 @@ Notes:
 
 - On desktop browsers, the `com.philips.air://...` request will fail to open. This is expected.
 - You can paste the full redirect URL or just the code value; the integration extracts the code automatically.
-- If the token expires, go to Integration > Configure and paste a new authorization code. No need to remove and re-add the integration.
+- If the token expires, go to Integration > Configure and re-authenticate. No need to remove and re-add the integration.
 
 ## Services
 
@@ -81,6 +95,7 @@ Entities are registered lazily: the integration waits for the device to report i
 Thanks to:
 - @vkostakos 
 - @markusstephany
+- @renaudallard — the email OTP authentication flow is adapted from the [Philips HomeID integration](https://github.com/renaudallard/homeassistant_philips_homeid)
 
 ## License
 

--- a/custom_components/philips_airplus/config_flow.py
+++ b/custom_components/philips_airplus/config_flow.py
@@ -15,8 +15,10 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .auth import PhilipsAirplusAuth, PhilipsAirplusOAuth2Implementation
 from .api import PhilipsAirplusAPIClient, PhilipsAirplusDevice
+from .email_auth import EmailOTPAuth, EmailOTPAuthError
 from .const import (
     AUTH_MODE_OAUTH,
+    AUTH_MODE_EMAIL_OTP,
     CONF_AUTH_MODE,
     CONF_CLIENT_ID,
     CONF_DEVICE_ID,
@@ -28,6 +30,7 @@ from .const import (
     CONF_USER_ID,
     DEFAULT_CLIENT_ID,
     DOMAIN,
+    OAUTH_CLIENT_ID_HOMEID,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,13 +53,198 @@ class PhilipsAirplusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._oauth_flow_id: Optional[str] = None
         self._oauth_authorize_url: Optional[str] = None
         self._reauth_entry: Optional[config_entries.ConfigEntry] = None
+        self._email: Optional[str] = None
+        self._vtoken: Optional[str] = None
 
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
         """Handle the initial step."""
-        self._client_id = DEFAULT_CLIENT_ID
-        return await self.async_step_oauth()
+        return await self.async_step_auth_method()
+
+    async def async_step_auth_method(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Choose authentication method."""
+        if self._reauth_entry:
+            # For reauth, use the entry's stored auth_mode
+            original_mode = self._reauth_entry.data.get(
+                CONF_AUTH_MODE, AUTH_MODE_OAUTH
+            )
+            if original_mode == AUTH_MODE_EMAIL_OTP:
+                self._auth_mode = AUTH_MODE_EMAIL_OTP
+                self._client_id = DEFAULT_CLIENT_ID
+                return await self.async_step_email()
+            self._auth_mode = AUTH_MODE_OAUTH
+            self._client_id = DEFAULT_CLIENT_ID
+            return await self.async_step_oauth()
+
+        if user_input is not None:
+            method = user_input.get("auth_method", AUTH_MODE_OAUTH)
+            if method == AUTH_MODE_EMAIL_OTP:
+                self._auth_mode = AUTH_MODE_EMAIL_OTP
+                self._client_id = DEFAULT_CLIENT_ID
+                return await self.async_step_email()
+            self._auth_mode = AUTH_MODE_OAUTH
+            self._client_id = DEFAULT_CLIENT_ID
+            return await self.async_step_oauth()
+
+        return self.async_show_form(
+            step_id="auth_method",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("auth_method", default=AUTH_MODE_OAUTH): vol.In(
+                        {
+                            AUTH_MODE_OAUTH: "OAuth PKCE (browser DevTools)",
+                            AUTH_MODE_EMAIL_OTP: "Email + verification code",
+                        }
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_email(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Enter email address and request OTP."""
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            email = (user_input.get("email") or "").strip()
+            if not email or "@" not in email:
+                errors["base"] = "invalid_email"
+            else:
+                self._email = email
+                try:
+                    email_auth = EmailOTPAuth(self.hass)
+                    self._vtoken = await email_auth.request_otp(email)
+                    await email_auth.close()
+                    return await self.async_step_email_otp()
+                except EmailOTPAuthError as ex:
+                    _LOGGER.error("OTP send failed: %s", ex)
+                    errors["base"] = "otp_send_failed"
+
+        return self.async_show_form(
+            step_id="email",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("email"): str,
+                }
+            ),
+            description_placeholders={"email": self._email or ""},
+            errors=errors,
+        )
+
+    async def async_step_email_otp(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Enter OTP code and complete authentication."""
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            code = (user_input.get("otp_code") or "").strip()
+            if not code:
+                errors["base"] = "missing_code"
+            else:
+                try:
+                    email_auth = EmailOTPAuth(self.hass)
+                    session_token = await email_auth.verify_otp(
+                        self._email or "", code, self._vtoken or ""
+                    )
+                    token_data = await email_auth.exchange_session_for_tokens(
+                        session_token
+                    )
+
+                    access_token = token_data.get("access_token")
+                    refresh_token = token_data.get("refresh_token")
+                    token_expires_at = token_data.get("token_expires_at")
+
+                    if not access_token:
+                        errors["base"] = "invalid_token"
+                        return self.async_show_form(
+                            step_id="email_otp",
+                            data_schema=vol.Schema(
+                                {vol.Required("otp_code"): str}
+                            ),
+                            description_placeholders={
+                                "email": self._email or ""
+                            },
+                            errors=errors,
+                        )
+
+                    # Validate token by listing devices
+                    api_client = PhilipsAirplusAPIClient(access_token)
+                    devices_data = await api_client.list_devices()
+                    await api_client.close()
+                    _LOGGER.info("IoT device list returned %d device(s)", len(devices_data))
+
+                    # Fallback: try HomeID client if Air+ tokens returned no devices
+                    if not devices_data:
+                        _LOGGER.info(
+                            "IoT device list empty with Air+ tokens, trying HomeID client fallback"
+                        )
+                        homeid_tokens = await email_auth.exchange_session_for_tokens_homeid_fallback()
+                        if homeid_tokens:
+                            homeid_access = homeid_tokens.get("access_token")
+                            if homeid_access:
+                                # Use HomeID tokens for device listing
+                                api_client2 = PhilipsAirplusAPIClient(homeid_access)
+                                devices_data = await api_client2.list_devices()
+                                await api_client2.close()
+                                _LOGGER.info(
+                                    "IoT device list with HomeID tokens: %d device(s)",
+                                    len(devices_data),
+                                )
+                                if not devices_data:
+                                    # Last resort: HomeID backend appliance API
+                                    devices_data = await email_auth.list_devices_via_homeid(
+                                        homeid_access
+                                    )
+                                if devices_data:
+                                    # Use HomeID tokens going forward
+                                    access_token = homeid_access
+                                    refresh_token = homeid_tokens.get("refresh_token")
+                                    token_expires_at = homeid_tokens.get("token_expires_at")
+                                    self._client_id = OAUTH_CLIENT_ID_HOMEID
+                                    self._auth_mode = AUTH_MODE_EMAIL_OTP
+
+                    await email_auth.close()
+
+                    self._access_token = access_token
+                    self._refresh_token = refresh_token
+                    self._token_expires_at = token_expires_at
+                    self._devices = [
+                        PhilipsAirplusDevice(d)
+                        for d in devices_data
+                    ]
+
+                    if not self._devices:
+                        errors["base"] = "no_devices"
+                        return self.async_show_form(
+                            step_id="email_otp",
+                            data_schema=vol.Schema(
+                                {vol.Required("otp_code"): str}
+                            ),
+                            description_placeholders={
+                                "email": self._email or ""
+                            },
+                            errors=errors,
+                        )
+
+                    return await self.async_step_select_device()
+
+                except EmailOTPAuthError as ex:
+                    _LOGGER.error("Email OTP auth failed: %s", ex)
+                    errors["base"] = "otp_verify_failed"
+
+        return self.async_show_form(
+            step_id="email_otp",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("otp_code"): str,
+                }
+            ),
+            description_placeholders={"email": self._email or ""},
+            errors=errors,
+        )
 
     async def async_step_oauth(
         self, user_input: Optional[Dict[str, Any]] = None
@@ -198,7 +386,7 @@ class PhilipsAirplusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             self._auth = PhilipsAirplusAuth(
                 self.hass,
-                auth_mode=AUTH_MODE_OAUTH,
+                auth_mode=self._auth_mode,
                 access_token=self._access_token,
             )
             self._auth._client_id = self._client_id
@@ -258,7 +446,7 @@ class PhilipsAirplusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
-        return await self.async_step_user()
+        return await self.async_step_auth_method()
 
     @staticmethod
     def async_get_options_flow(
@@ -277,11 +465,21 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
         self._client_id: Optional[str] = config_entry.data.get(
             CONF_CLIENT_ID, DEFAULT_CLIENT_ID
         )
+        self._auth_mode = config_entry.data.get(CONF_AUTH_MODE, AUTH_MODE_OAUTH)
         self._oauth_flow_id: Optional[str] = None
         self._oauth_authorize_url: Optional[str] = None
+        self._email: Optional[str] = None
+        self._vtoken: Optional[str] = None
 
     def _build_init_schema(self, enable_mqtt: bool, auth_code: str = "") -> vol.Schema:
         """Build options form schema."""
+        if self._auth_mode == AUTH_MODE_EMAIL_OTP:
+            return vol.Schema(
+                {
+                    vol.Optional(CONF_ENABLE_MQTT, default=enable_mqtt): bool,
+                    vol.Optional("email", default=""): str,
+                }
+            )
         return vol.Schema(
             {
                 vol.Optional(CONF_ENABLE_MQTT, default=enable_mqtt): bool,
@@ -296,6 +494,18 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
         errors: Optional[Dict[str, str]] = None,
     ) -> FlowResult:
         """Render options form with current placeholders."""
+        if self._auth_mode == AUTH_MODE_EMAIL_OTP:
+            device_name = self._entry.data.get(CONF_DEVICE_NAME, "Unknown")
+            return self.async_show_form(
+                step_id="init",
+                data_schema=self._build_init_schema(enable_mqtt),
+                errors=errors or {},
+                description_placeholders={
+                    "device_name": device_name,
+                    "authorize_url": "",
+                },
+            )
+
         if not self._oauth_flow_id or not self._oauth_authorize_url:
             self._oauth_flow_id = secrets.token_urlsafe(8)
             impl = PhilipsAirplusOAuth2Implementation(
@@ -324,6 +534,24 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
             return await self._async_show_init_form(enable_mqtt)
 
         enable_mqtt = user_input.get(CONF_ENABLE_MQTT, enable_mqtt)
+
+        if self._auth_mode == AUTH_MODE_EMAIL_OTP:
+            email = (user_input.get("email") or "").strip()
+            if email:
+                self._email = email
+                try:
+                    email_auth = EmailOTPAuth(self.hass)
+                    self._vtoken = await email_auth.request_otp(email)
+                    await email_auth.close()
+                    return await self.async_step_email_otp_options()
+                except EmailOTPAuthError as ex:
+                    _LOGGER.error("Options OTP send failed: %s", ex)
+                    return await self._async_show_init_form(
+                        enable_mqtt,
+                        errors={"base": "otp_send_failed"},
+                    )
+            return self.async_create_entry(title="", data={CONF_ENABLE_MQTT: enable_mqtt})
+
         auth_code = (user_input.get("auth_code") or "").strip()
 
         if auth_code:
@@ -413,3 +641,89 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
                 )
 
         return self.async_create_entry(title="", data={CONF_ENABLE_MQTT: enable_mqtt})
+
+    async def async_step_email_otp_options(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Enter OTP code for options re-authentication."""
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            code = (user_input.get("otp_code") or "").strip()
+            if not code:
+                errors["base"] = "missing_code"
+            else:
+                try:
+                    email_auth = EmailOTPAuth(self.hass)
+                    session_token = await email_auth.verify_otp(
+                        self._email or "", code, self._vtoken or ""
+                    )
+                    token_data = await email_auth.exchange_session_for_tokens(
+                        session_token
+                    )
+
+                    access_token = token_data.get("access_token")
+                    refresh_token = token_data.get("refresh_token")
+                    token_expires_at = token_data.get("token_expires_at")
+
+                    await email_auth.close()
+
+                    if not access_token:
+                        errors["base"] = "invalid_token"
+
+                    if not errors:
+                        auth = PhilipsAirplusAuth(
+                            self.hass,
+                            auth_mode=AUTH_MODE_EMAIL_OTP,
+                            access_token=access_token,
+                            refresh_token=refresh_token,
+                            client_id=self._client_id,
+                        )
+                        auth_ok = await auth.initialize()
+                        user_id = auth.user_id
+                        await auth.close()
+
+                        if auth_ok:
+                            updated_data = {**self._entry.data}
+                            updated_data[CONF_ACCESS_TOKEN] = access_token
+                            updated_data[CONF_REFRESH_TOKEN] = refresh_token
+                            updated_data[CONF_TOKEN_EXPIRES_AT] = token_expires_at
+                            updated_data[CONF_USER_ID] = user_id
+                            updated_data[CONF_CLIENT_ID] = self._client_id
+                            self.hass.config_entries.async_update_entry(
+                                self._entry, data=updated_data
+                            )
+                            self.hass.async_create_task(
+                                self.hass.config_entries.async_reload(
+                                    self._entry.entry_id
+                                )
+                            )
+                            _LOGGER.info(
+                                "Options email re-authentication succeeded and entry was reloaded"
+                            )
+                            return self.async_create_entry(
+                                title="",
+                                data={
+                                    CONF_ENABLE_MQTT: self._entry.options.get(
+                                        CONF_ENABLE_MQTT, True
+                                    )
+                                },
+                            )
+                        errors["base"] = "auth_failed"
+
+                except EmailOTPAuthError as ex:
+                    _LOGGER.error("Options email OTP auth failed: %s", ex)
+                    errors["base"] = "otp_verify_failed"
+                except Exception as ex:
+                    _LOGGER.exception("Options email OTP reauth failed: %s", ex)
+                    errors["base"] = "auth_failed"
+
+        return self.async_show_form(
+            step_id="email_otp_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("otp_code"): str,
+                }
+            ),
+            description_placeholders={"email": self._email or ""},
+            errors=errors,
+        )

--- a/custom_components/philips_airplus/const.py
+++ b/custom_components/philips_airplus/const.py
@@ -35,6 +35,21 @@ KEEPALIVE = 60
 
 # Authentication
 AUTH_MODE_OAUTH = "oauth"
+AUTH_MODE_EMAIL_OTP = "email_otp"
+
+# Gigya CDC API (email + OTP authentication)
+GIGYA_API_KEY = "4_JGZWlP8eQHpEqkvQElolbA"
+GIGYA_API_URL = "https://cdc.accounts.home.id"
+GIGYA_OTP_SEND_ENDPOINT = f"{GIGYA_API_URL}/accounts.auth.otp.email.sendCode"
+GIGYA_OTP_LOGIN_ENDPOINT = f"{GIGYA_API_URL}/accounts.auth.otp.email.login"
+GIGYA_SOCIALIZE_GET_IDS = f"{GIGYA_API_URL}/socialize.getIDs"
+
+# OIDC endpoints for the HomeID client (used by email OTP path)
+OIDC_HOMEID_ISSUER = f"https://cdc.accounts.home.id/oidc/op/v1.0/{GIGYA_API_KEY}"
+OIDC_HOMEID_AUTH = f"{OIDC_HOMEID_ISSUER}/authorize"
+OIDC_HOMEID_TOKEN = f"{OIDC_HOMEID_ISSUER}/token"
+OAUTH_CLIENT_ID_HOMEID = "-u6aTznrxp9_9e_0a57CpvEG"
+MOBILE_APP_REDIRECT_URI_HOMEID = "com.philips.ka.oneka.app.prod://oauthredirect"
 
 
 PORT_FILTER_READ = "filtRd"

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -713,7 +713,7 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             self._reconnect_task = None
 
         if self._mqtt_client:
-            self._mqtt_client.disconnect()
+            self._mqtt_client.shutdown()
 
         if self._auth:
             await self._auth.close()

--- a/custom_components/philips_airplus/coordinator.py
+++ b/custom_components/philips_airplus/coordinator.py
@@ -313,17 +313,9 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                                         "Token expired and cannot be refreshed for %s, re-authentication required",
                                         self._device_name,
                                     )
-                                    # Raising ConfigEntryAuthFailed from a background
-                                    # task does NOT trigger HA's reauth flow, it just
-                                    # kills this task. Start the reauth flow explicitly.
                                     self.entry.async_start_reauth(self.hass)
                                     return
 
-                                # The custom-authorizer signature must match the
-                                # current access token, so refresh it before every
-                                # reconnect attempt. A stale signature (e.g. after a
-                                # failed fetch during token refresh) would otherwise
-                                # make every attempt fail until the next token cycle.
                                 await self._auth.refresh_signature()
                                 self._mqtt_client.access_token = (
                                     self._auth.access_token or ""
@@ -332,18 +324,34 @@ class PhilipsAirplusDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                                     self._auth.signature or ""
                                 )
 
-                                if await self._mqtt_client.async_connect():
-                                    _LOGGER.info(
-                                        "MQTT reconnection successful for %s",
-                                        self._device_name,
-                                    )
-                                    break
-                                else:
-                                    _LOGGER.warning(
-                                        "MQTT reconnection failed for %s, retrying in %ss",
-                                        self._device_name, min(delay * 2, max_delay),
-                                    )
-                                    delay = min(delay * 2, max_delay)
+                                # Prevent entities from flickering to unavailable
+                                # while the old client is torn down and replaced.
+                                self._mqtt_client._refreshing_credentials = True
+                                try:
+                                    if await self._mqtt_client.async_connect():
+                                        _LOGGER.info(
+                                            "MQTT reconnection successful for %s",
+                                            self._device_name,
+                                        )
+                                        break
+                                    else:
+                                        _LOGGER.warning(
+                                            "MQTT reconnection failed for %s, retrying in %ss",
+                                            self._device_name, min(delay * 2, max_delay),
+                                        )
+                                        delay = min(delay * 2, max_delay)
+                                finally:
+                                    # If the reconnect failed while the flag was set,
+                                    # fire the disconnect callback now. Otherwise the
+                                    # integration stays offline until reload.
+                                    if not self._mqtt_client.is_connected() and self._mqtt_client._connection_callback:
+                                        try:
+                                            self.hass.loop.call_soon_threadsafe(
+                                                self._mqtt_client._connection_callback, False
+                                            )
+                                        except Exception:
+                                            pass
+                                    self._mqtt_client._refreshing_credentials = False
                             except ConfigEntryAuthFailed:
                                 raise
                             except Exception as ex:

--- a/custom_components/philips_airplus/email_auth.py
+++ b/custom_components/philips_airplus/email_auth.py
@@ -1,0 +1,492 @@
+"""Email + OTP authentication for Philips Air+ via Gigya CDC."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import secrets
+import time
+import urllib.parse
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
+from typing import Any
+from typing import Optional
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    API_BASE_URL,
+    DEFAULT_CLIENT_ID,
+    DEVICE_ENDPOINT,
+    GIGYA_API_KEY,
+    GIGYA_API_URL,
+    GIGYA_OTP_SEND_ENDPOINT,
+    GIGYA_OTP_LOGIN_ENDPOINT,
+    GIGYA_SOCIALIZE_GET_IDS,
+    HTTP_USER_AGENT,
+    MOBILE_APP_REDIRECT_URI_HOMEID,
+    OAUTH_CLIENT_ID_HOMEID,
+    OIDC_DEFAULT_REDIRECT_URI,
+    OIDC_DEFAULT_SCOPES,
+    OIDC_DEFAULT_ISSUER_BASE,
+    OIDC_DEFAULT_TENANT_SEGMENT,
+    OIDC_HOMEID_ISSUER,
+    OIDC_HOMEID_TOKEN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Scopes matching the Philips HomeID app (prompt=none compatible)
+OAUTH_SCOPES_HOMEID = (
+    "openid profile email offline_access "
+    "DI.Account.read DI.AccountProfile.read DI.AccountProfile.write "
+    "DI.AccountGeneralConsent.read DI.AccountGeneralConsent.write "
+    "DI.GeneralConsent.read DI.GeneralConsent.write "
+    "VoiceProvider.read VoiceProvider.write "
+    "subscriptions consent profile_extended "
+    "DI.AccountSubscription.write DI.AccountSubscription.read"
+)
+
+# HomeID backend base (for appliance discovery fallback)
+HOMEID_BACKEND_BASE = "https://www.backend.vbs.versuni.com"
+HOMEID_BACKEND_API = f"{HOMEID_BACKEND_BASE}/api"
+HOMEID_ACCEPT = "application/vnd.oneka.v2.0+json"
+HOMEID_USER_AGENT = (
+    "HomeID/8.16.0 (com.philips.ka.oneka.app; build:8160001; Android 14)"
+)
+HOMEID_X_USER_AGENT = "Android 14;8.16.0"
+
+
+class EmailOTPAuthError(Exception):
+    """Error during email OTP authentication."""
+
+
+class EmailOTPAuth:
+    """Handles Gigya email OTP authentication and OIDC token exchange.
+
+    Defaults to the Philips Air+ OIDC client so the resulting tokens are
+    accepted by the IoT device-list API.  Stores the Gigya session token
+    internally so callers who get zero devices from the IoT API can call
+    ``exchange_session_for_tokens_homeid_fallback()`` to obtain HomeID
+    tokens instead.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        client_id: str = DEFAULT_CLIENT_ID,
+        redirect_uri: str = OIDC_DEFAULT_REDIRECT_URI,
+        scopes: str = OIDC_DEFAULT_SCOPES,
+        issuer_base: str = OIDC_DEFAULT_ISSUER_BASE,
+        tenant_segment: str = OIDC_DEFAULT_TENANT_SEGMENT,
+    ) -> None:
+        self.hass = hass
+        self._client_id = client_id
+        self._redirect_uri = redirect_uri
+        self._scopes = scopes
+        self._issuer_base = issuer_base.rstrip("/")
+        self._tenant_segment = tenant_segment
+        self._authorize_url = (
+            f"{self._issuer_base}/{self._tenant_segment}/authorize"
+        )
+        self._token_url = f"{self._issuer_base}/{self._tenant_segment}/token"
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._session_token: Optional[str] = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    async def request_otp(self, email: str) -> str:
+        """Send OTP code to email. Returns vToken for verification."""
+        session = await self._get_session()
+        params = {
+            "email": email.strip(),
+            "apiKey": GIGYA_API_KEY,
+            "format": "json",
+        }
+
+        _LOGGER.debug("Requesting OTP for %s", email)
+        try:
+            async with session.post(GIGYA_OTP_SEND_ENDPOINT, data=params) as resp:
+                data = await resp.json(content_type=None)
+        except aiohttp.ClientError as ex:
+            raise EmailOTPAuthError(f"OTP endpoint unreachable: {ex}") from ex
+        except json.JSONDecodeError as ex:
+            raise EmailOTPAuthError(
+                f"OTP endpoint returned non-JSON (HTTP {resp.status})"
+            ) from ex
+
+        error_code = data.get("errorCode", -1)
+        if error_code != 0:
+            msg = data.get("errorMessage", "Unknown error")
+            raise EmailOTPAuthError(f"OTP send failed: {msg} (code {error_code})")
+
+        vtoken = data.get("vToken")
+        if not vtoken:
+            raise EmailOTPAuthError("No vToken in OTP send response")
+
+        _LOGGER.debug("OTP sent to %s", email)
+        return vtoken
+
+    async def verify_otp(self, email: str, code: str, vtoken: str) -> str:
+        """Verify OTP code. Returns Gigya session token."""
+        session = await self._get_session()
+        params = {
+            "email": email.strip(),
+            "code": code.strip(),
+            "vToken": vtoken,
+            "apiKey": GIGYA_API_KEY,
+            "format": "json",
+        }
+
+        _LOGGER.debug("Verifying OTP for %s", email)
+        try:
+            async with session.post(GIGYA_OTP_LOGIN_ENDPOINT, data=params) as resp:
+                data = await resp.json(content_type=None)
+        except aiohttp.ClientError as ex:
+            raise EmailOTPAuthError(f"OTP verify endpoint unreachable: {ex}") from ex
+        except json.JSONDecodeError as ex:
+            raise EmailOTPAuthError(
+                f"OTP verify returned non-JSON (HTTP {resp.status})"
+            ) from ex
+
+        error_code = data.get("errorCode", -1)
+        if error_code == 206001:
+            raise EmailOTPAuthError(
+                "Account pending registration: this email is not a fully "
+                "registered Philips account. Sign in once in the Philips "
+                "HomeID app to complete registration, then try again."
+            )
+        if error_code != 0:
+            msg = data.get("errorMessage", "Unknown error")
+            raise EmailOTPAuthError(f"OTP verification failed: {msg}")
+
+        session_token = data.get("sessionInfo", {}).get("cookieValue")
+        if not session_token:
+            raise EmailOTPAuthError("No session token in OTP verify response")
+
+        _LOGGER.debug("OTP verified for %s", email)
+        return session_token
+
+    async def exchange_session_for_tokens(self, session_token: str) -> dict[str, Any]:
+        """Exchange Gigya session token for OIDC access/refresh tokens via pure HTTP."""
+        self._session_token = session_token
+        code_verifier = secrets.token_urlsafe(64)
+        code_challenge = (
+            urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+
+        auth_code = await self._http_oauth(session_token, code_challenge)
+        return await self._exchange_code(auth_code, code_verifier)
+
+    async def exchange_session_for_tokens_homeid_fallback(self) -> dict[str, Any] | None:
+        """Re-use the stored session token to get HomeID OIDC tokens.
+
+        Returns None if no session token is stored or exchange fails.
+        Use when the IoT API returns no devices with the Air+ tokens.
+        """
+        if not self._session_token:
+            return None
+        try:
+            code_verifier = secrets.token_urlsafe(64)
+            code_challenge = (
+                urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+                .rstrip(b"=")
+                .decode()
+            )
+            auth_code = await self._http_oauth(
+                self._session_token, code_challenge,
+                client_id=OAUTH_CLIENT_ID_HOMEID,
+                redirect_uri=MOBILE_APP_REDIRECT_URI_HOMEID,
+                scopes=OAUTH_SCOPES_HOMEID,
+            )
+            return await self._exchange_code(
+                auth_code, code_verifier,
+                client_id=OAUTH_CLIENT_ID_HOMEID,
+                redirect_uri=MOBILE_APP_REDIRECT_URI_HOMEID,
+            )
+        except EmailOTPAuthError as ex:
+            _LOGGER.warning("HomeID fallback exchange failed: %s", ex)
+            return None
+
+    async def _http_oauth(self, session_token: str, code_challenge: str,
+                          client_id: str | None = None,
+                          redirect_uri: str | None = None,
+                          scopes: str | None = None) -> str:
+        """Pure-HTTP OAuth flow with prompt=none. Returns authorization code."""
+        session = await self._get_session()
+        cid = client_id or self._client_id
+        ruri = redirect_uri or self._redirect_uri
+        sc = scopes or self._scopes
+
+        # Step 1: GET /authorize?prompt=none → expect redirect with context JWT
+        auth_params = {
+            "client_id": cid,
+            "response_type": "code",
+            "redirect_uri": ruri,
+            "scope": sc,
+            "state": secrets.token_urlsafe(16),
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "prompt": "none",
+        }
+        auth_url = f"{self._authorize_url}?{urllib.parse.urlencode(auth_params)}"
+
+        async with session.get(auth_url, allow_redirects=False) as resp:
+            if resp.status not in (301, 302, 303, 307, 308):
+                body = (await resp.text())[:300]
+                raise EmailOTPAuthError(
+                    f"/authorize: expected redirect, got HTTP {resp.status}: {body}"
+                )
+            location = resp.headers.get("Location", "")
+
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+        context_jwt = (query.get("context") or [""])[0]
+        if not context_jwt:
+            raise EmailOTPAuthError(
+                f"/authorize: no 'context' in redirect ({location[:200]})"
+            )
+
+        # Step 2: POST socialize.getIDs → get gmidTicket
+        async with session.post(
+            GIGYA_SOCIALIZE_GET_IDS,
+            data={
+                "APIKey": GIGYA_API_KEY,
+                "includeTicket": "true",
+                "format": "json",
+            },
+        ) as resp:
+            ids_data = await resp.json(content_type=None)
+        gmid_ticket = ids_data.get("gmidTicket")
+        if not gmid_ticket:
+            err = ids_data.get("errorMessage") or ids_data.get("errorCode")
+            raise EmailOTPAuthError(f"socialize.getIDs returned no gmidTicket: {err}")
+
+        # Step 3: GET /authorize/continue → expect redirect with code
+        issuer = f"{self._issuer_base}/{self._tenant_segment}"
+        cont_params = {
+            "context": context_jwt,
+            "login_token": session_token,
+            "gmidTicket": gmid_ticket,
+            "client_id": cid,
+        }
+        cont_url = (
+            f"{issuer}/authorize/continue?"
+            f"{urllib.parse.urlencode(cont_params)}"
+        )
+        async with session.get(cont_url, allow_redirects=False) as resp:
+            if resp.status not in (301, 302, 303, 307, 308):
+                body = (await resp.text())[:300]
+                raise EmailOTPAuthError(
+                    f"/authorize/continue: expected redirect, got HTTP {resp.status}: {body}"
+                )
+            location = resp.headers.get("Location", "")
+
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+        if query.get("errorMessage"):
+            raise EmailOTPAuthError(
+                f"/authorize/continue: {query['errorMessage'][0]}"
+            )
+        auth_code = (query.get("code") or [""])[0]
+        if not auth_code:
+            raise EmailOTPAuthError(
+                f"/authorize/continue: no 'code' in redirect ({location[:200]})"
+            )
+        return auth_code
+
+    async def _exchange_code(self, code: str, code_verifier: str,
+                             client_id: str | None = None,
+                             redirect_uri: str | None = None) -> dict[str, Any]:
+        """Exchange authorization code for OIDC tokens."""
+        session = await self._get_session()
+        cid = client_id or self._client_id
+        ruri = redirect_uri or self._redirect_uri
+        data = {
+            "client_id": cid,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": ruri,
+            "code_verifier": code_verifier,
+        }
+
+        _LOGGER.debug("Exchanging auth code for tokens at %s", self._token_url)
+        async with session.post(self._token_url, data=data) as resp:
+            text = await resp.text()
+            try:
+                result = json.loads(text)
+            except json.JSONDecodeError:
+                raise EmailOTPAuthError(
+                    f"Token exchange response not JSON: {text[:200]}"
+                )
+
+        if "access_token" not in result:
+            error = result.get("error_description", result.get("error", "Unknown"))
+            raise EmailOTPAuthError(f"Token exchange failed: {error}")
+
+        _LOGGER.debug(
+            "OIDC tokens obtained (scopes: %s, expires_in: %s)",
+            result.get("scope", "?"),
+            result.get("expires_in", "?"),
+        )
+
+        normalized: dict[str, Any] = {
+            "access_token": result.get("access_token"),
+            "refresh_token": result.get("refresh_token"),
+        }
+
+        exp = result.get("exp")
+        expires_in = result.get("expires_in")
+        if exp:
+            normalized["token_expires_at"] = int(exp)
+        elif expires_in:
+            normalized["token_expires_at"] = int(
+                (datetime.now() + timedelta(seconds=int(expires_in))).timestamp()
+            )
+
+        return normalized
+
+    # ------------------------------------------------------------------
+    # HomeID backend API fallback – used when the IoT API returns no
+    # devices for tokens obtained via the HomeID client.
+    # ------------------------------------------------------------------
+
+    async def list_devices_via_homeid(self, access_token: str) -> list[dict[str, Any]]:
+        """Discover appliances via the HomeID backend HAL API."""
+        session = await self._get_session()
+
+        # 1. Discovery
+        discovery_url = f"{HOMEID_BACKEND_BASE}/.well-known/tenant/oneka"
+        _LOGGER.info("HomeID discovery: GET %s", discovery_url)
+        async with session.get(discovery_url) as resp:
+            if resp.status != 200:
+                _LOGGER.warning("HomeID discovery failed: HTTP %s", resp.status)
+                return []
+            discovery = await resp.json(content_type=None)
+            _LOGGER.debug("HomeID discovery body: %s", json.dumps(discovery)[:2000])
+
+        profile_url = discovery.get("profileUrl")
+        if not profile_url:
+            _LOGGER.warning("HomeID discovery missing profileUrl, keys: %s", list(discovery.keys()))
+            return []
+        if profile_url.startswith("/"):
+            profile_url = f"{HOMEID_BACKEND_API}{profile_url}"
+
+        ts = int(time.time() * 1000)
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": HOMEID_ACCEPT,
+            "Accept-Language": "en-GB",
+            "User-Agent": HOMEID_USER_AGENT,
+            "X-USER-AGENT": HOMEID_X_USER_AGENT,
+        }
+
+        # 2. Profile
+        profile_req = f"{profile_url}?ts={ts}"
+        _LOGGER.info("HomeID profile: GET %s", profile_req)
+        async with session.get(profile_req, headers=headers) as resp:
+            if resp.status != 200:
+                _LOGGER.warning(
+                    "HomeID profile failed: HTTP %s, body: %s",
+                    resp.status,
+                    (await resp.text())[:500],
+                )
+                return []
+            profile = await resp.json(content_type=None)
+            _LOGGER.debug("HomeID profile body: %s", json.dumps(profile)[:2000])
+
+        # Check for embedded appliances
+        embedded = profile.get("_embedded", {})
+        appliances_embedded = embedded.get("userAppliances", {})
+        if isinstance(appliances_embedded, dict):
+            items = appliances_embedded.get("_embedded", {}).get("item", [])
+            if items:
+                _LOGGER.info("HomeID: %d embedded appliance(s) in profile", len(items))
+                for it in items:
+                    _LOGGER.debug("  Appliance: name=%s externalDeviceId=%s ctn=%s",
+                                  it.get("name"), it.get("externalDeviceId"), it.get("ctn"))
+                return self._normalize_appliances(items)
+
+        # Follow userAppliances link
+        links = profile.get("_links", {})
+        _LOGGER.debug("HomeID profile _links keys: %s", list(links.keys()))
+        appliances_link = links.get("userAppliances", {})
+        href = (
+            appliances_link.get("href", "")
+            if isinstance(appliances_link, dict)
+            else ""
+        )
+        if not href:
+            # Try alternative link names
+            for alt in ("customerAppliances", "appliances", "devices"):
+                alt_link = links.get(alt, {})
+                href = alt_link.get("href", "") if isinstance(alt_link, dict) else ""
+                if href:
+                    _LOGGER.debug("Found appliances via '%s' link", alt)
+                    break
+        if not href:
+            _LOGGER.warning("HomeID profile has no appliance links, _links keys: %s", list(links.keys()))
+            return []
+        if href.startswith("/"):
+            href = f"{HOMEID_BACKEND_API}{href}"
+        href = re.sub(r"\{[^}]*\}", "", href)
+
+        # 3. Appliances
+        appliances_req = f"{href}?ts={ts}"
+        _LOGGER.info("HomeID appliances: GET %s", appliances_req)
+        async with session.get(appliances_req, headers=headers) as resp:
+            if resp.status != 200:
+                _LOGGER.warning(
+                    "HomeID appliances failed: HTTP %s, body: %s",
+                    resp.status,
+                    (await resp.text())[:500],
+                )
+                return []
+            data = await resp.json(content_type=None)
+            _LOGGER.debug("HomeID appliances body: %s", json.dumps(data)[:2000])
+
+        if isinstance(data, dict):
+            items = data.get("_embedded", {}).get("item", [])
+        elif isinstance(data, list):
+            items = data
+        else:
+            items = []
+        _LOGGER.info("HomeID: %d appliance(s) from API", len(items))
+        for it in items:
+            _LOGGER.debug("  Appliance: name=%s externalDeviceId=%s ctn=%s",
+                          it.get("name"), it.get("externalDeviceId"), it.get("ctn"))
+        return self._normalize_appliances(items)
+
+    @staticmethod
+    def _normalize_appliances(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert HomeID appliance dicts to IoT-compatible format."""
+        out: list[dict[str, Any]] = []
+        for item in items:
+            name = item.get("name") or item.get("friendlyName") or "Unknown"
+            mac = item.get("macAddress", "")
+            ctn = item.get("ctn") or item.get("modelNumber") or item.get("deviceType") or ""
+            device_id = item.get("externalDeviceId") or item.get("id") or mac
+            uuid_val = item.get("uuid") or device_id
+            out.append({
+                "uuid": uuid_val,
+                "id": device_id,
+                "name": name,
+                "deviceName": name,
+                "friendlyName": name,
+                "ctn": ctn,
+                "type": ctn or "unknown",
+                "macAddress": mac,
+            })
+        return out

--- a/custom_components/philips_airplus/manifest.json
+++ b/custom_components/philips_airplus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "philips_airplus",
   "name": "Philips Air+",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "documentation": "https://github.com/ShorMeneses/philips-airplus-homeassistant",
   "issue_tracker": "https://github.com/ShorMeneses/philips-airplus-homeassistant/issues",
   "dependencies": [],

--- a/custom_components/philips_airplus/mqtt_client.py
+++ b/custom_components/philips_airplus/mqtt_client.py
@@ -304,10 +304,16 @@ class PhilipsAirplusMQTTClient:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._blocking_connect)
 
+    def shutdown(self) -> None:
+        """Permanent shutdown — suppress all future callbacks."""
+        self._shutting_down = True
+        self.disconnect()
+
     def disconnect(self) -> None:
         """Disconnect from MQTT broker."""
         with self._lock:
-            self._shutting_down = True
+            if self._shutting_down:
+                return
             if self._client:
                 try:
                     self._client.loop_stop()

--- a/custom_components/philips_airplus/mqtt_client.py
+++ b/custom_components/philips_airplus/mqtt_client.py
@@ -64,6 +64,7 @@ class PhilipsAirplusMQTTClient:
         self._message_callback: Optional[Callable[[Dict[str, Any]], None]] = None
         self._connection_callback: Optional[Callable[[bool], None]] = None
         self._refreshing_credentials: bool = False  # Flag to maintain availability during credential refresh
+        self._shutting_down: bool = False  # Suppress callbacks during shutdown
         
         self.outbound_topic = TOPIC_CONTROL_TEMPLATE.format(device_id=self.device_id)
         self.inbound_topic = TOPIC_STATUS_TEMPLATE.format(device_id=self.device_id)
@@ -122,16 +123,36 @@ class PhilipsAirplusMQTTClient:
                 self._connection_callback(False)
 
     def _on_message(self, client: mqtt.Client, userdata: Any, msg: MQTTMessage) -> None:
-        """Handle incoming MQTT messages."""
+        """Handle incoming MQTT messages.
+
+        The AWS IoT broker may deliver multiple JSON payloads concatenated
+        in a single WebSocket frame.  Use raw_decode to process every
+        object in sequence instead of dropping the entire batch.
+        """
         try:
             payload = msg.payload.decode('utf-8')
-            message_data = json.loads(payload)
-            
-            _LOGGER.debug("Received message: %s", message_data)
-            
-            if self._message_callback:
-                self._message_callback(message_data)
-                
+            decoder = json.JSONDecoder()
+            idx = 0
+            while idx < len(payload):
+                # Skip leading whitespace between objects
+                while idx < len(payload) and payload[idx] in ' \t\n\r':
+                    idx += 1
+                if idx >= len(payload):
+                    break
+                try:
+                    message_data, end = decoder.raw_decode(payload, idx)
+                except json.JSONDecodeError:
+                    # Single-object fallback for the common case
+                    message_data = json.loads(payload[idx:])
+                    end = len(payload)
+
+                _LOGGER.debug("Received message: %s", message_data)
+
+                if self._message_callback:
+                    self._message_callback(message_data)
+
+                idx = end
+
         except json.JSONDecodeError as ex:
             _LOGGER.error("Failed to decode MQTT message: %s", ex)
         except Exception as ex:
@@ -140,6 +161,8 @@ class PhilipsAirplusMQTTClient:
     def _on_disconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
         """Handle MQTT disconnect events."""
         _LOGGER.debug("Disconnected from MQTT with rc=%s", rc)
+        if self._shutting_down:
+            return
         if rc != 0:
             _LOGGER.warning("MQTT unexpected disconnect rc=%s", rc)
             try:
@@ -171,7 +194,7 @@ class PhilipsAirplusMQTTClient:
     def _blocking_connect(self, timeout: float = 15.0) -> bool:
         """Connect to MQTT broker."""
         with self._lock:
-            if self._connecting:
+            if self._shutting_down or self._connecting:
                 return False
             if self._connected:
                 return True
@@ -284,6 +307,7 @@ class PhilipsAirplusMQTTClient:
     def disconnect(self) -> None:
         """Disconnect from MQTT broker."""
         with self._lock:
+            self._shutting_down = True
             if self._client:
                 try:
                     self._client.loop_stop()

--- a/custom_components/philips_airplus/strings.json
+++ b/custom_components/philips_airplus/strings.json
@@ -1,6 +1,13 @@
 {
   "config": {
     "step": {
+      "auth_method": {
+        "title": "Authentication Method",
+        "description": "Choose how you want to authenticate with your Philips account.\n\n**OAuth PKCE** — requires opening a browser and using DevTools Network tab to capture a redirect URL. Only works for accounts registered via the **Philips Air+ app**.\n\n**Email + verification code** — simpler: enter your email, receive a code, enter it. Works with both **Philips Air+** and **Philips HomeID** accounts.",
+        "data": {
+          "auth_method": "Authentication Method"
+        }
+      },
       "oauth": {
         "title": "Philips Air+ Authentication",
         "description": "1) Open this login URL in your browser:\n{authorize_url}\n\n2) Open DevTools (F12) → Network tab — before logging in.\n3) Complete Philips login and authorize the app.\n4) Find the `com.philips.air://loginredirect?code=...` redirect in the Network tab and copy the full URL.\n5) Paste it into the field below.",
@@ -21,14 +28,38 @@
       "reauth_confirm": {
         "title": "Re-authenticate Philips Air+",
         "description": "Your authentication token has expired. Please re-authenticate to continue using your Philips Air+ device."
+      },
+      "email": {
+        "title": "Philips Air+ Email Authentication",
+        "description": "Enter the email address associated with your Philips account. A verification code will be sent to this address.",
+        "data": {
+          "email": "Email Address"
+        }
+      },
+      "email_otp": {
+        "title": "Philips Air+ Verification Code",
+        "description": "A verification code has been sent to **{email}**. Check your inbox and enter the code below.",
+        "data": {
+          "otp_code": "Verification Code"
+        }
+      },
+      "email_otp_options": {
+        "title": "Philips Air+ Verification Code",
+        "description": "A verification code has been sent to **{email}**. Check your inbox and enter the code below.",
+        "data": {
+          "otp_code": "Verification Code"
+        }
       }
     },
     "error": {
       "missing_code": "Authorization code is required.",
+      "invalid_email": "Please enter a valid email address.",
       "invalid_token": "Invalid access token. Please check your token and try again.",
       "no_devices": "No devices found in your Philips Air+ account.",
       "auth_failed": "Authentication failed. Please try again.",
       "cannot_connect": "Unable to connect to Philips Air+ service.",
+      "otp_send_failed": "Failed to send verification code. Check your email address and try again.",
+      "otp_verify_failed": "Failed to verify the code. Make sure you entered it correctly.",
       "unknown": "Unexpected error during authentication."
     },
     "abort": {

--- a/custom_components/philips_airplus/translations/de.json
+++ b/custom_components/philips_airplus/translations/de.json
@@ -1,6 +1,13 @@
 {
   "config": {
     "step": {
+      "auth_method": {
+        "title": "Authentifizierungsmethode",
+        "description": "Wähle, wie du dich bei deinem Philips-Konto authentifizieren möchtest.\n\n**OAuth PKCE** — Browser öffnen, DevTools-Netzwerk-Tab verwenden, um die Weiterleitungs-URL zu erfassen. Funktioniert nur mit Konten der **Philips Air+ App**.\n\n**Email + Bestätigungscode** — einfacher: E-Mail eingeben, Code empfangen, eingeben. Funktioniert mit **Philips Air+** und **Philips HomeID**.",
+        "data": {
+          "auth_method": "Authentifizierungsmethode"
+        }
+      },
       "oauth": {
         "title": "Philips Air+ Authentifizierung",
         "description": "1) Öffne diese Login-URL im Browser:\n{authorize_url}\n\n2) DevTools öffnen (F12) → Netzwerk-Tab – vor dem Einloggen.\n3) Philips-Login durchführen und App autorisieren.\n4) Im Netzwerk-Tab die Weiterleitung zu `com.philips.air://loginredirect?code=...` suchen und die vollständige URL kopieren.\n5) URL unten einfügen.",
@@ -21,14 +28,38 @@
       "reauth_confirm": {
         "title": "Philips Air+ erneut authentifizieren",
         "description": "Dein Authentifizierungstoken ist abgelaufen. Bitte authentifiziere dich erneut, um dein Philips Air+ Gerät weiter nutzen zu können."
+      },
+      "email": {
+        "title": "Philips Air+ E-Mail-Authentifizierung",
+        "description": "Gib die E-Mail-Adresse deines Philips-Kontos ein. Ein Bestätigungscode wird an diese Adresse gesendet.",
+        "data": {
+          "email": "E-Mail-Adresse"
+        }
+      },
+      "email_otp": {
+        "title": "Philips Air+ Bestätigungscode",
+        "description": "Ein Bestätigungscode wurde an **{email}** gesendet. Überprüfe deinen Posteingang und gib den Code unten ein.",
+        "data": {
+          "otp_code": "Bestätigungscode"
+        }
+      },
+      "email_otp_options": {
+        "title": "Philips Air+ Bestätigungscode",
+        "description": "Ein Bestätigungscode wurde an **{email}** gesendet. Überprüfe deinen Posteingang und gib den Code unten ein.",
+        "data": {
+          "otp_code": "Bestätigungscode"
+        }
       }
     },
     "error": {
       "missing_code": "Autorisierungscode ist erforderlich.",
+      "invalid_email": "Bitte gib eine gültige E-Mail-Adresse ein.",
       "invalid_token": "Ungültiger Zugriffstoken. Bitte überprüfe deinen Token und versuche es erneut.",
       "no_devices": "Keine Geräte in deinem Philips Air+ Konto gefunden.",
       "auth_failed": "Authentifizierung fehlgeschlagen. Bitte versuche es erneut.",
       "cannot_connect": "Verbindung zum Philips Air+ Dienst nicht möglich.",
+      "otp_send_failed": "Senden des Bestätigungscodes fehlgeschlagen. Überprüfe deine E-Mail-Adresse und versuche es erneut.",
+      "otp_verify_failed": "Überprüfung des Codes fehlgeschlagen. Stelle sicher, dass du ihn korrekt eingegeben hast.",
       "unknown": "Unerwarteter Fehler bei der Authentifizierung."
     },
     "abort": {

--- a/custom_components/philips_airplus/translations/en.json
+++ b/custom_components/philips_airplus/translations/en.json
@@ -1,6 +1,13 @@
 {
   "config": {
     "step": {
+      "auth_method": {
+        "title": "Authentication Method",
+        "description": "Choose how you want to authenticate with your Philips account.\n\n**OAuth PKCE** — requires opening a browser and using DevTools Network tab to capture a redirect URL. Only works for accounts registered via the **Philips Air+ app**.\n\n**Email + verification code** — simpler: enter your email, receive a code, enter it. Works with both **Philips Air+** and **Philips HomeID** accounts.",
+        "data": {
+          "auth_method": "Authentication Method"
+        }
+      },
       "oauth": {
         "title": "Philips Air+ Authentication",
         "description": "1) Open this login URL in your browser:\n{authorize_url}\n\n2) Open DevTools (F12) → Network tab — before logging in.\n3) Complete Philips login and authorize the app.\n4) Find the `com.philips.air://loginredirect?code=...` redirect in the Network tab and copy the full URL.\n5) Paste it into the field below.",
@@ -21,14 +28,38 @@
       "reauth_confirm": {
         "title": "Re-authenticate Philips Air+",
         "description": "Your authentication token has expired. Please re-authenticate to continue using your Philips Air+ device."
+      },
+      "email": {
+        "title": "Philips Air+ Email Authentication",
+        "description": "Enter the email address associated with your Philips account. A verification code will be sent to this address.",
+        "data": {
+          "email": "Email Address"
+        }
+      },
+      "email_otp": {
+        "title": "Philips Air+ Verification Code",
+        "description": "A verification code has been sent to **{email}**. Check your inbox and enter the code below.",
+        "data": {
+          "otp_code": "Verification Code"
+        }
+      },
+      "email_otp_options": {
+        "title": "Philips Air+ Verification Code",
+        "description": "A verification code has been sent to **{email}**. Check your inbox and enter the code below.",
+        "data": {
+          "otp_code": "Verification Code"
+        }
       }
     },
     "error": {
       "missing_code": "Authorization code is required.",
+      "invalid_email": "Please enter a valid email address.",
       "invalid_token": "Invalid access token. Please check your token and try again.",
       "no_devices": "No devices found in your Philips Air+ account.",
       "auth_failed": "Authentication failed. Please try again.",
       "cannot_connect": "Unable to connect to Philips Air+ service.",
+      "otp_send_failed": "Failed to send verification code. Check your email address and try again.",
+      "otp_verify_failed": "Failed to verify the code. Make sure you entered it correctly.",
       "unknown": "Unexpected error during authentication."
     },
     "abort": {

--- a/custom_components/philips_airplus/translations/fr.json
+++ b/custom_components/philips_airplus/translations/fr.json
@@ -1,6 +1,13 @@
 {
   "config": {
     "step": {
+      "auth_method": {
+        "title": "Méthode d'authentification",
+        "description": "Choisissez comment vous souhaitez vous authentifier avec votre compte Philips.\n\n**OAuth PKCE** — nécessite d'ouvrir un navigateur et d'utiliser l'onglet Réseau des DevTools pour capturer l'URL de redirection. Fonctionne uniquement avec l'app **Philips Air+**.\n\n**Email + code de vérification** — plus simple : entrez votre email, recevez un code, saisissez-le. Fonctionne avec **Philips Air+** et **Philips HomeID**.",
+        "data": {
+          "auth_method": "Méthode d'authentification"
+        }
+      },
       "oauth": {
         "title": "Authentification Philips Air+",
         "description": "1) Ouvrez cette URL de connexion dans votre navigateur :\n{authorize_url}\n\n2) Ouvrez les DevTools (F12) → onglet Réseau — avant de vous connecter.\n3) Effectuez la connexion Philips et autorisez l'application.\n4) Dans l'onglet Réseau, trouvez la redirection vers `com.philips.air://loginredirect?code=...` et copiez l'URL complète.\n5) Collez-la dans le champ ci-dessous.",
@@ -21,14 +28,38 @@
       "reauth_confirm": {
         "title": "Ré-authentifier Philips Air+",
         "description": "Votre jeton d'authentification a expiré. Veuillez vous ré-authentifier pour continuer à utiliser votre appareil Philips Air+."
+      },
+      "email": {
+        "title": "Authentification Philips Air+ par e-mail",
+        "description": "Entrez l'adresse e-mail associée à votre compte Philips. Un code de vérification sera envoyé à cette adresse.",
+        "data": {
+          "email": "Adresse e-mail"
+        }
+      },
+      "email_otp": {
+        "title": "Code de vérification Philips Air+",
+        "description": "Un code de vérification a été envoyé à **{email}**. Vérifiez votre boîte de réception et saisissez le code ci-dessous.",
+        "data": {
+          "otp_code": "Code de vérification"
+        }
+      },
+      "email_otp_options": {
+        "title": "Code de vérification Philips Air+",
+        "description": "Un code de vérification a été envoyé à **{email}**. Vérifiez votre boîte de réception et saisissez le code ci-dessous.",
+        "data": {
+          "otp_code": "Code de vérification"
+        }
       }
     },
     "error": {
       "missing_code": "Le code d'autorisation est requis.",
+      "invalid_email": "Veuillez entrer une adresse e-mail valide.",
       "invalid_token": "Jeton d'accès invalide. Veuillez vérifier votre jeton et réessayer.",
       "no_devices": "Aucun appareil trouvé dans votre compte Philips Air+.",
       "auth_failed": "Échec de l'authentification. Veuillez réessayer.",
       "cannot_connect": "Impossible de se connecter au service Philips Air+.",
+      "otp_send_failed": "Échec de l'envoi du code de vérification. Vérifiez votre adresse e-mail et réessayez.",
+      "otp_verify_failed": "Échec de la vérification du code. Assurez-vous de l'avoir saisi correctement.",
       "unknown": "Erreur inattendue lors de l'authentification."
     },
     "abort": {


### PR DESCRIPTION
Add email+verification-code authentication via Gigya CDC as an alternative to the OAuth PKCE browser flow. No DevTools required. Works with both Philips Air+ and Philips HomeID accounts.

New file:
- email_auth.py: Gigya OTP send/verify, prompt=none OAuth, OIDC token exchange with automatic Air+/HomeID client fallback

Modified:
- config_flow.py: auth method selection, email+OTP steps, auto- reauth routing, dual-client device discovery fallback
- const.py: Gigya CDC endpoints, HomeID OIDC constants, auth modes
- coordinator.py: _refreshing_credentials flag in reconnect task to prevent entity unavailable flicker during reconnection
- mqtt_client.py: JSONDecoder.raw_decode() for batched MQTT payloads (fixes rc=7 disconnects from "Extra data" errors); _shutting_down flag to suppress zombie callbacks from cancelled reconnect tasks during config entry reload/unload
- strings.json + translations/*.json: new UI strings (4 languages)
- README.md: document both auth methods, credit renaudallard

Adapted from the Philips HomeID integration by @renaudallard.