### PR TITLE
fix: clarify options re-auth UI + prevent zombie MQTT on reload

### DIFF
--- a/custom_components/philips_airplus/config_flow.py
+++ b/custom_components/philips_airplus/config_flow.py
@@ -494,15 +494,20 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
         errors: Optional[Dict[str, str]] = None,
     ) -> FlowResult:
         """Render options form with current placeholders."""
+        device_name = self._entry.data.get(CONF_DEVICE_NAME, "Unknown")
+
         if self._auth_mode == AUTH_MODE_EMAIL_OTP:
-            device_name = self._entry.data.get(CONF_DEVICE_NAME, "Unknown")
             return self.async_show_form(
                 step_id="init",
                 data_schema=self._build_init_schema(enable_mqtt),
                 errors=errors or {},
                 description_placeholders={
                     "device_name": device_name,
-                    "authorize_url": "",
+                    "reauth_instructions": (
+                        "This integration was set up with email authentication. "
+                        "To re-authenticate, enter your email below to receive a "
+                        "new verification code."
+                    ),
                 },
             )
 
@@ -513,14 +518,22 @@ class PhilipsAirplusOptionsFlowHandler(config_entries.OptionsFlow):
             )
             self._oauth_authorize_url = await impl.async_generate_authorize_url(self._oauth_flow_id)
 
-        device_name = self._entry.data.get(CONF_DEVICE_NAME, "Unknown")
         return self.async_show_form(
             step_id="init",
             data_schema=self._build_init_schema(enable_mqtt, auth_code),
             errors=errors or {},
             description_placeholders={
                 "device_name": device_name,
-                "authorize_url": self._oauth_authorize_url,
+                "reauth_instructions": (
+                    "To re-authenticate via OAuth:\n\n"
+                    "1) Open this URL in your browser:\n"
+                    f"{self._oauth_authorize_url}\n\n"
+                    "2) Open DevTools (F12) → Network tab before logging in.\n"
+                    "3) Complete Philips login and authorize the app.\n"
+                    "4) Find the `com.philips.air://loginredirect?code=...` "
+                    "redirect and copy the full URL.\n"
+                    "5) Paste it into the field below."
+                ),
             },
         )
 

--- a/custom_components/philips_airplus/manifest.json
+++ b/custom_components/philips_airplus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "philips_airplus",
   "name": "Philips Air+",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "documentation": "https://github.com/ShorMeneses/philips-airplus-homeassistant",
   "issue_tracker": "https://github.com/ShorMeneses/philips-airplus-homeassistant/issues",
   "dependencies": [],

--- a/custom_components/philips_airplus/mqtt_client.py
+++ b/custom_components/philips_airplus/mqtt_client.py
@@ -305,25 +305,28 @@ class PhilipsAirplusMQTTClient:
         return await loop.run_in_executor(None, self._blocking_connect)
 
     def shutdown(self) -> None:
-        """Permanent shutdown — suppress all future callbacks."""
+        """Permanent shutdown — tear down connection and suppress callbacks."""
         self._shutting_down = True
-        self.disconnect()
+        self._disconnect_internal()
 
     def disconnect(self) -> None:
-        """Disconnect from MQTT broker."""
+        """Disconnect from MQTT broker (used for clean reconnection)."""
+        self._disconnect_internal()
+
+    def _disconnect_internal(self) -> None:
+        """Actually tear down the paho connection and network thread."""
         with self._lock:
-            if self._shutting_down:
+            if self._client is None:
                 return
-            if self._client:
-                try:
-                    self._client.loop_stop()
-                    self._client.disconnect()
-                    _LOGGER.debug("MQTT disconnected")
-                except Exception as ex:
-                    _LOGGER.error("Error disconnecting MQTT: %s", ex)
-                finally:
-                    self._client = None
-            self._connected = False
+            try:
+                self._client.loop_stop()
+                self._client.disconnect()
+                _LOGGER.debug("MQTT disconnected")
+            except Exception as ex:
+                _LOGGER.error("Error disconnecting MQTT: %s", ex)
+            finally:
+                self._client = None
+        self._connected = False
 
     def is_connected(self) -> bool:
         """Check if MQTT client is connected.

--- a/custom_components/philips_airplus/strings.json
+++ b/custom_components/philips_airplus/strings.json
@@ -72,14 +72,16 @@
     "step": {
       "init": {
         "title": "Philips Air+ Options",
-        "description": "Device: {device_name}\n\nTo re-authenticate:\n1) Open this login URL in your browser:\n{authorize_url}\n\n2) Open DevTools (F12) → Network tab — before logging in.\n3) Complete Philips login and authorize the app.\n4) Find the `com.philips.air://loginredirect?code=...` redirect and copy the full URL.\n5) Paste it into the field below.\n\nLeave the field empty to keep current tokens unchanged.",
+        "description": "Device: {device_name}\n\n{reauth_instructions}\n\nLeave the field empty to keep current tokens unchanged.",
         "data": {
           "enable_mqtt": "Enable MQTT",
-          "auth_code": "Authorization Code (optional)"
+          "auth_code": "Authorization Code (optional)",
+          "email": "Email (optional)"
         },
         "data_description": {
           "enable_mqtt": "Disable to stop cloud/MQTT activity for this integration",
-          "auth_code": "Paste a fresh OAuth code to re-authenticate without removing the integration"
+          "auth_code": "Paste a fresh OAuth code to re-authenticate without removing the integration",
+          "email": "Enter your email to receive a new verification code"
         }
       }
     }

--- a/custom_components/philips_airplus/translations/de.json
+++ b/custom_components/philips_airplus/translations/de.json
@@ -72,14 +72,16 @@
     "step": {
       "init": {
         "title": "Philips Air+ Optionen",
-        "description": "Gerät: {device_name}\n\nZur erneuten Authentifizierung:\n1) Öffne diese Login-URL im Browser:\n{authorize_url}\n\n2) DevTools öffnen (F12) → Netzwerk-Tab – vor dem Einloggen.\n3) Philips-Login durchführen und App autorisieren.\n4) Im Netzwerk-Tab die Weiterleitung zu `com.philips.air://loginredirect?code=...` suchen und die vollständige URL kopieren.\n5) URL unten einfügen.\n\nFeld leer lassen, um die aktuellen Token unverändert zu behalten.",
+        "description": "Gerät: {device_name}\n\n{reauth_instructions}\n\nFeld leer lassen, um die aktuellen Token unverändert zu behalten.",
         "data": {
           "enable_mqtt": "MQTT aktivieren",
-          "auth_code": "Autorisierungscode (optional)"
+          "auth_code": "Autorisierungscode (optional)",
+          "email": "E-Mail (optional)"
         },
         "data_description": {
           "enable_mqtt": "Deaktivieren, um Cloud-/MQTT-Aktivität für diese Integration zu stoppen",
-          "auth_code": "Neuen OAuth-Code einfügen, um sich ohne Entfernen der Integration neu zu authentifizieren"
+          "auth_code": "Neuen OAuth-Code einfügen, um sich ohne Entfernen der Integration neu zu authentifizieren",
+          "email": "Gib deine E-Mail-Adresse ein, um einen neuen Bestätigungscode zu erhalten"
         }
       }
     }

--- a/custom_components/philips_airplus/translations/en.json
+++ b/custom_components/philips_airplus/translations/en.json
@@ -72,14 +72,16 @@
     "step": {
       "init": {
         "title": "Philips Air+ Options",
-        "description": "Device: {device_name}\n\nTo re-authenticate:\n1) Open this login URL in your browser:\n{authorize_url}\n\n2) Open DevTools (F12) → Network tab — before logging in.\n3) Complete Philips login and authorize the app.\n4) Find the `com.philips.air://loginredirect?code=...` redirect and copy the full URL.\n5) Paste it into the field below.\n\nLeave the field empty to keep current tokens unchanged.",
+        "description": "Device: {device_name}\n\n{reauth_instructions}\n\nLeave the field empty to keep current tokens unchanged.",
         "data": {
           "enable_mqtt": "Enable MQTT",
-          "auth_code": "Authorization Code (optional)"
+          "auth_code": "Authorization Code (optional)",
+          "email": "Email (optional)"
         },
         "data_description": {
           "enable_mqtt": "Disable to stop cloud/MQTT activity for this integration",
-          "auth_code": "Paste a fresh OAuth code to re-authenticate without removing the integration"
+          "auth_code": "Paste a fresh OAuth code to re-authenticate without removing the integration",
+          "email": "Enter your email to receive a new verification code"
         }
       }
     }

--- a/custom_components/philips_airplus/translations/fr.json
+++ b/custom_components/philips_airplus/translations/fr.json
@@ -72,14 +72,16 @@
     "step": {
       "init": {
         "title": "Options Philips Air+",
-        "description": "Appareil : {device_name}\n\nPour se ré-authentifier :\n1) Ouvrez cette URL de connexion dans votre navigateur :\n{authorize_url}\n\n2) Ouvrez les DevTools (F12) → onglet Réseau — avant de vous connecter.\n3) Effectuez la connexion Philips et autorisez l'application.\n4) Trouvez la redirection vers `com.philips.air://loginredirect?code=...` et copiez l'URL complète.\n5) Collez-la dans le champ ci-dessous.\n\nLaissez le champ vide pour conserver les jetons actuels.",
+        "description": "Appareil : {device_name}\n\n{reauth_instructions}\n\nLaissez le champ vide pour conserver les jetons actuels.",
         "data": {
           "enable_mqtt": "Activer MQTT",
-          "auth_code": "Code d'autorisation (optionnel)"
+          "auth_code": "Code d'autorisation (optionnel)",
+          "email": "Email (optionnel)"
         },
         "data_description": {
           "enable_mqtt": "Désactiver pour arrêter l'activité cloud/MQTT de cette intégration",
-          "auth_code": "Collez un nouveau code OAuth pour se ré-authentifier sans supprimer l'intégration"
+          "auth_code": "Collez un nouveau code OAuth pour se ré-authentifier sans supprimer l'intégration",
+          "email": "Entrez votre email pour recevoir un nouveau code de vérification"
         }
       }
     }


### PR DESCRIPTION
1. Options re-auth screen now shows mode-appropriate instructions:
   - Email OTP users: "Enter your email to receive a new code"
   - PKCE users: full OAuth URL with DevTools guide Previously the PKCE instructions appeared for everyone with an empty URL placeholder, confusing email OTP users.

2. `_disconnect_internal()` extracted from `disconnect()` so `shutdown()` can tear down the paho client before suppressing callbacks.  Previously `shutdown()` set `_shutting_down` then called `disconnect()` which immediately returned — the old WebSocket stayed alive, AWS IoT kicked it with rc=7 when the reloaded entry's client connected with the same client_id.